### PR TITLE
StructPath

### DIFF
--- a/src/features/JSONPath/core/createPath/scalarValue.ts
+++ b/src/features/JSONPath/core/createPath/scalarValue.ts
@@ -3,7 +3,7 @@ import type {
   ScalarParam,
   ArrayParamTypes,
 } from "@RmmzPluginSchema/rmmz/plugin";
-import type { ArrayParamPathPair } from "./types";
+import type { ArrayParamPathPairEx } from "./types";
 
 export const makeScalarValuesPath = (
   scalas: ReadonlyArray<PluginParamEx<ScalarParam>>,
@@ -16,12 +16,12 @@ export const makeScalarValuesPath = (
   return `${parent}[${itesm}]`;
 };
 
-export const makeScalarArrayPath = (
-  scalaArrays: ReadonlyArray<PluginParamEx<ArrayParamTypes>>,
+export const makeScalarArrayPath = <T extends PluginParamEx<ArrayParamTypes>>(
+  scalaArrays: ReadonlyArray<T>,
   parent: string
-): ArrayParamPathPair[] => {
+): ArrayParamPathPairEx<T>[] => {
   return scalaArrays.map(
-    (param): ArrayParamPathPair => ({
+    (param): ArrayParamPathPairEx<T> => ({
       path: `${parent}.${param.name}[*]`,
       param: param,
     })

--- a/src/features/JSONPath/core/createPath/structValue.empty.test.ts
+++ b/src/features/JSONPath/core/createPath/structValue.empty.test.ts
@@ -22,7 +22,7 @@ describe("empty struct", () => {
     const structMap: ReadonlyMap<string, ClassifiedPluginParams> = new Map([
       ["EmptyStruct", schema],
     ]);
-    const result = getPathFromStructParam([param], "$", structMap);
+    const result = getPathFromStructParam(param, "$", structMap);
     expect(result.items).toEqual([]);
   });
   test("", () => {
@@ -39,7 +39,7 @@ describe("empty struct", () => {
     const structMap: ReadonlyMap<string, ClassifiedPluginParams> = new Map([
       ["NotEmptyStruct", schema],
     ]);
-    const result = getPathFromStructParam([param], "$", structMap);
+    const result = getPathFromStructParam(param, "$", structMap);
     const expected: StructPropertysPath[] = [
       {
         category: "struct",
@@ -72,7 +72,7 @@ describe("empty struct", () => {
     const structMap: ReadonlyMap<string, ClassifiedPluginParams> = new Map([
       ["EmptyStructArray", schema],
     ]);
-    const result = getPathFromStructParam([param], "$", structMap);
+    const result = getPathFromStructParam(param, "$", structMap);
     const expected: StructPropertysPath[] = [
       {
         category: "struct",

--- a/src/features/JSONPath/core/createPath/structValue.empty.test.ts
+++ b/src/features/JSONPath/core/createPath/structValue.empty.test.ts
@@ -1,7 +1,10 @@
 import { describe, test, expect } from "vitest";
 import type {
   ClassifiedPluginParams,
+  ClassifiedPluginParamsEx2,
+  NumberArrayParam,
   PluginParamEx,
+  ScalarParam,
   StructRefParam,
 } from "@RmmzPluginSchema/rmmz/plugin";
 import { getPathFromStructParam } from "./structValue";
@@ -54,7 +57,7 @@ describe("empty struct", () => {
     expect(result.items).toEqual(expected);
   });
   test("struct array", () => {
-    const schema: ClassifiedPluginParams = {
+    const schema: ClassifiedPluginParamsEx2<ScalarParam, NumberArrayParam> = {
       scalars: [],
       scalarArrays: [
         {

--- a/src/features/JSONPath/core/createPath/structValue.error.test.ts
+++ b/src/features/JSONPath/core/createPath/structValue.error.test.ts
@@ -39,7 +39,7 @@ describe("cyclic struct", () => {
       attr: { kind: "struct", struct: "LoopMock" },
     } as const satisfies PluginParamEx<StructRefParam>;
     const result: StructPathResultWithError = getPathFromStructParam(
-      [param],
+      param,
       "$",
       structMap
     );
@@ -63,7 +63,7 @@ describe("undefined struct", () => {
       attr: { kind: "struct", struct: "UndefinedStruct" },
     } as const satisfies PluginParamEx<StructRefParam>;
     const result: StructPathResultWithError = getPathFromStructParam(
-      [param],
+      param,
       "$",
       structMap
     );

--- a/src/features/JSONPath/core/createPath/structValue.scalaOnly.test.ts
+++ b/src/features/JSONPath/core/createPath/structValue.scalaOnly.test.ts
@@ -4,6 +4,7 @@ import type {
   PluginParamEx,
   StructRefParam,
   ClassifiedPluginParams,
+  ScalarParam,
 } from "@RmmzPluginSchema/rmmz/plugin";
 import { toObjectPluginParams } from "@RmmzPluginSchema/rmmz/plugin";
 import { JSONPathJS } from "jsonpath-js";
@@ -48,7 +49,7 @@ describe("person", () => {
           param: personSchema.scalarArrays[1],
         },
       ],
-      objectSchema: toObjectPluginParams(personSchema.scalars),
+      objectSchema: toObjectPluginParams<ScalarParam>(personSchema.scalars),
     },
   ] as const satisfies StructPropertysPath[];
   test("getPathFromStruct", () => {

--- a/src/features/JSONPath/core/createPath/structValue.scalaOnly.test.ts
+++ b/src/features/JSONPath/core/createPath/structValue.scalaOnly.test.ts
@@ -59,7 +59,7 @@ describe("person", () => {
     const structMap: ReadonlyMap<string, ClassifiedPluginParams> = new Map([
       ["MockPerson", personSchema],
     ]);
-    const result = getPathFromStructParam([param], "$", structMap);
+    const result = getPathFromStructParam(param, "$", structMap);
     expect(result.items).toEqual(expected);
   });
 

--- a/src/features/JSONPath/core/createPath/structValue.structArray.test.ts
+++ b/src/features/JSONPath/core/createPath/structValue.structArray.test.ts
@@ -1,12 +1,12 @@
 import { describe, test, expect } from "vitest";
 import type {
   ClassifiedPluginParamsEx,
-  ClassifiedPluginParams,
   PluginParamEx,
   StructRefParam,
   NumberParam,
   NumberArrayParam,
   StringParam,
+  ClassifiedPluginParamsEx2,
 } from "@RmmzPluginSchema/rmmz/plugin";
 import { getPathFromStructParam } from "./structValue";
 import type { StructPropertysPath, StructPathResultWithError } from "./types";
@@ -27,7 +27,10 @@ interface ClassRoom {
   items: Item[];
 }
 
-const personSchema: ClassifiedPluginParamsEx<Person> = {
+const personSchema: ClassifiedPluginParamsEx<
+  Person,
+  NumberParam | StringParam
+> = {
   scalarArrays: [],
   structs: [],
   structArrays: [],
@@ -53,7 +56,7 @@ const classRoomSchema: ClassifiedPluginParamsEx<ClassRoom> = {
   ],
 };
 
-const itemSchema: ClassifiedPluginParamsEx<Item> = {
+const itemSchema: ClassifiedPluginParamsEx<Item, NumberParam | StringParam> = {
   scalarArrays: [],
   structs: [],
   structArrays: [],
@@ -63,9 +66,12 @@ const itemSchema: ClassifiedPluginParamsEx<Item> = {
   ],
 };
 
-const structsMap: ReadonlyMap<string, ClassifiedPluginParams> = new Map<
+const structsMap: ReadonlyMap<
   string,
-  ClassifiedPluginParams
+  ClassifiedPluginParamsEx2<NumberParam | StringParam, NumberArrayParam>
+> = new Map<
+  string,
+  ClassifiedPluginParamsEx2<NumberParam | StringParam, NumberArrayParam>
 >([
   ["Person", personSchema],
   ["ClassRoom", classRoomSchema],
@@ -73,10 +79,7 @@ const structsMap: ReadonlyMap<string, ClassifiedPluginParams> = new Map<
 ]);
 
 describe("getPathFromStructParam", () => {
-  type Struct = StructPropertysPathEx3<
-    NumberParam | StringParam,
-    NumberArrayParam
-  >;
+  type Struct = StructPropertysPathEx3<NumberParam | StringParam, never>;
   const path1: Struct = {
     category: "struct",
     name: "Person",

--- a/src/features/JSONPath/core/createPath/structValue.structArray.test.ts
+++ b/src/features/JSONPath/core/createPath/structValue.structArray.test.ts
@@ -91,11 +91,12 @@ describe("getPathFromStructParam", () => {
   };
 
   test("classRoom.students", () => {
-    const params: ReadonlyArray<PluginParamEx<StructRefParam>> = [
-      { name: "classRoom", attr: { kind: "struct", struct: "ClassRoom" } },
-    ];
+    const param: PluginParamEx<StructRefParam> = {
+      name: "classRoom",
+      attr: { kind: "struct", struct: "ClassRoom" },
+    };
     const result: StructPathResultWithError = getPathFromStructParam(
-      params,
+      param,
       "$",
       structsMap
     );

--- a/src/features/JSONPath/core/createPath/structValue.structArray.test.ts
+++ b/src/features/JSONPath/core/createPath/structValue.structArray.test.ts
@@ -4,9 +4,13 @@ import type {
   ClassifiedPluginParams,
   PluginParamEx,
   StructRefParam,
+  NumberParam,
+  NumberArrayParam,
+  StringParam,
 } from "@RmmzPluginSchema/rmmz/plugin";
 import { getPathFromStructParam } from "./structValue";
 import type { StructPropertysPath, StructPathResultWithError } from "./types";
+import type { StructPropertysPathEx3 } from "./types/template";
 
 interface Person {
   name: string;
@@ -69,7 +73,11 @@ const structsMap: ReadonlyMap<string, ClassifiedPluginParams> = new Map<
 ]);
 
 describe("getPathFromStructParam", () => {
-  const path1: StructPropertysPath = {
+  type Struct = StructPropertysPathEx3<
+    NumberParam | StringParam,
+    NumberArrayParam
+  >;
+  const path1: Struct = {
     category: "struct",
     name: "Person",
     objectSchema: {
@@ -79,7 +87,7 @@ describe("getPathFromStructParam", () => {
     scalarArrays: [],
     scalarsPath: '$.classRoom.students[*]["name","age"]',
   };
-  const path2: StructPropertysPath = {
+  const path2: Struct = {
     category: "struct",
     name: "Item",
     objectSchema: {

--- a/src/features/JSONPath/core/createPath/structValue.ts
+++ b/src/features/JSONPath/core/createPath/structValue.ts
@@ -2,9 +2,9 @@ import type {
   ArrayParamTypes,
   ClassifiedPluginParams,
   ClassifiedPluginParamsEx2,
-  ClassifiedPluginParamsEx3,
   PluginParamEx,
   ScalarParam,
+  ScalaStruct,
   StructArrayRefParam,
   StructRefParam,
 } from "@RmmzPluginSchema/rmmz/plugin";
@@ -21,6 +21,16 @@ const ERROR_CODE = {
   undefinedStruct: "undefined_struct",
   cyclicStruct: "cyclic_struct",
 } as const satisfies ErrorCodes;
+
+interface ClassifiedPluginParamsEx3<
+  S extends PluginParamEx<ScalarParam>,
+  A extends PluginParamEx<ArrayParamTypes>
+> extends ScalaStruct {
+  structs: PluginParamEx<StructRefParam>[];
+  structArrays: PluginParamEx<StructArrayRefParam>[];
+  scalars: S[];
+  scalarArrays: A[];
+}
 
 interface Frame {
   schemaName: string;

--- a/src/features/JSONPath/core/createPath/structValue.ts
+++ b/src/features/JSONPath/core/createPath/structValue.ts
@@ -10,11 +10,7 @@ import type {
 } from "@RmmzPluginSchema/rmmz/plugin";
 import { toObjectPluginParams } from "@RmmzPluginSchema/rmmz/plugin";
 import { makeScalarArrayPath, makeScalarValuesPath } from "./scalarValue";
-import type {
-  ErrorCodes,
-  StructPathError,
-  StructPathResultWithError,
-} from "./types";
+import type { ErrorCodes, StructPathError } from "./types";
 import type { StructPropertysPathEx3, TemplateGE } from "./types/template";
 
 const ERROR_CODE = {
@@ -167,7 +163,7 @@ function collectFromSchema<S extends ScalarParam, A extends ArrayParamTypes>(
   basePath: string,
   structMap: ReadonlyMap<string, ClassifiedPluginParamsEx2<S, A>>,
   errors: ErrorCodes
-): StructPathResultWithError {
+): TemplateGE<S, A> {
   type StateType = State2<S, A>;
   const state: StateType = {
     items: [],
@@ -212,15 +208,15 @@ export const getPathFromStructParam = <
 };
 
 export const getPathFromStructArraySchema = <
-  S extends PluginParamEx<ScalarParam>,
-  A extends PluginParamEx<ArrayParamTypes>
+  S extends ScalarParam,
+  A extends ArrayParamTypes
 >(
   param: PluginParamEx<StructArrayRefParam>,
   parent: string,
-  structMap: ReadonlyMap<string, ClassifiedPluginParamsEx3<S, A>>,
+  structMap: ReadonlyMap<string, ClassifiedPluginParamsEx2<S, A>>,
   errors: ErrorCodes = ERROR_CODE
-): TemplateGE<S["attr"], A["attr"]> => {
-  return collectFromSchema(
+): TemplateGE<S, A> => {
+  return collectFromSchema<S, A>(
     param.attr.struct,
     `${parent}.${param.name}[*]`,
     structMap,

--- a/src/features/JSONPath/core/createPath/structValue.ts
+++ b/src/features/JSONPath/core/createPath/structValue.ts
@@ -1,6 +1,7 @@
 import type {
   ArrayParamTypes,
   ClassifiedPluginParams,
+  ClassifiedPluginParamsEx2,
   ClassifiedPluginParamsEx3,
   PluginParamEx,
   ScalarParam,
@@ -33,11 +34,8 @@ interface State2<Scalar extends ScalarParam, Array extends ArrayParamTypes> {
   errs: StructPathError[];
 }
 
-function createNode<
-  S extends PluginParamEx<ScalarParam>,
-  A extends PluginParamEx<ArrayParamTypes>
->(
-  structSchema: ClassifiedPluginParamsEx3<S, A>,
+function createNode<S extends ScalarParam, A extends ArrayParamTypes>(
+  structSchema: ClassifiedPluginParamsEx2<S, A>,
   {
     path,
     structName,
@@ -45,7 +43,7 @@ function createNode<
     path: string;
     structName: string;
   }
-): StructPropertysPathEx3<S["attr"], A["attr"]> {
+): StructPropertysPathEx3<S, A> {
   return {
     category: "struct",
     objectSchema: toObjectPluginParams(structSchema.scalars),
@@ -88,10 +86,7 @@ function createChildFrames(
 
 function stepState<Scalar extends ScalarParam, Array extends ArrayParamTypes>(
   state: State2<Scalar, Array>,
-  structMap: ReadonlyMap<
-    string,
-    ClassifiedPluginParamsEx3<PluginParamEx<Scalar>, PluginParamEx<Array>>
-  >,
+  structMap: ReadonlyMap<string, ClassifiedPluginParamsEx2<Scalar, Array>>,
   errors: ErrorCodes
 ): State2<Scalar, Array> {
   if (state.frames.length === 0) {
@@ -157,16 +152,13 @@ function stepState<Scalar extends ScalarParam, Array extends ArrayParamTypes>(
   };
 }
 
-function collectFromSchema<
-  S extends PluginParamEx<ScalarParam>,
-  A extends PluginParamEx<ArrayParamTypes>
->(
+function collectFromSchema<S extends ScalarParam, A extends ArrayParamTypes>(
   schemaName: string,
   basePath: string,
-  structMap: ReadonlyMap<string, ClassifiedPluginParamsEx3<S, A>>,
+  structMap: ReadonlyMap<string, ClassifiedPluginParamsEx2<S, A>>,
   errors: ErrorCodes
 ): StructPathResultWithError {
-  type StateType = State2<S["attr"], A["attr"]>;
+  type StateType = State2<S, A>;
   const state: StateType = {
     items: [],
     errs: [],

--- a/src/features/JSONPath/core/createPath/structValue.ts
+++ b/src/features/JSONPath/core/createPath/structValue.ts
@@ -191,12 +191,15 @@ function collectFromSchema<
   return { items: finalState.items, errors: finalState.errs };
 }
 
-export const getPathFromStructParam = (
+export const getPathFromStructParam = <
+  S extends PluginParamEx<ScalarParam>,
+  A extends PluginParamEx<ArrayParamTypes>
+>(
   params: PluginParamEx<StructRefParam>,
   parent: string,
-  structMap: ReadonlyMap<string, ClassifiedPluginParams>,
+  structMap: ReadonlyMap<string, ClassifiedPluginParamsEx3<S, A>>,
   errors: ErrorCodes = ERROR_CODE
-): StructPathResultWithError => {
+): TemplateGE<S["attr"], A["attr"]> => {
   // 各パラメータから構造体名を取得し、collectFromSchemaで集約
   return collectFromSchema(
     params.attr.struct,
@@ -210,30 +213,27 @@ export const getPathFromStructArraySchema = <
   S extends PluginParamEx<ScalarParam>,
   A extends PluginParamEx<ArrayParamTypes>
 >(
-  param: ReadonlyArray<PluginParamEx<StructArrayRefParam>>,
+  param: PluginParamEx<StructArrayRefParam>,
   parent: string,
   structMap: ReadonlyMap<string, ClassifiedPluginParamsEx3<S, A>>,
   errors: ErrorCodes = ERROR_CODE
 ): TemplateGE<S["attr"], A["attr"]> => {
-  const reuslts = param.map((p) =>
-    collectFromSchema(
-      p.attr.struct,
-      `${parent}.${p.name}[*]`,
-      structMap,
-      errors
-    )
+  return collectFromSchema(
+    param.attr.struct,
+    `${parent}.${param.name}[*]`,
+    structMap,
+    errors
   );
-  return {
-    items: reuslts.flatMap((r) => r.items),
-    errors: reuslts.flatMap((r) => r.errors),
-  };
 };
 
-export const getPathFromStructSchema = (
+export const getPathFromStructSchema = <
+  S extends PluginParamEx<ScalarParam>,
+  A extends PluginParamEx<ArrayParamTypes>
+>(
   structName: string,
   parent: string,
-  structMap: ReadonlyMap<string, ClassifiedPluginParams>,
+  structMap: ReadonlyMap<string, ClassifiedPluginParamsEx3<S, A>>,
   errors: ErrorCodes = ERROR_CODE
-): StructPathResultWithError => {
+): TemplateGE<S["attr"], A["attr"]> => {
   return collectFromSchema(structName, parent, structMap, errors);
 };

--- a/src/features/JSONPath/core/createPath/types/array.ts
+++ b/src/features/JSONPath/core/createPath/types/array.ts
@@ -7,3 +7,10 @@ export interface ArrayParamPathPair {
   path: `${string}[*]`;
   param: PluginParamEx<ArrayParamTypes>;
 }
+
+export interface ArrayParamPathPairEx<
+  T extends PluginParamEx<ArrayParamTypes>
+> {
+  path: `${string}[*]`;
+  param: T;
+}

--- a/src/features/JSONPath/core/createPath/types/bundle.ts
+++ b/src/features/JSONPath/core/createPath/types/bundle.ts
@@ -1,12 +1,28 @@
-import type { ParamKinds, ScalarParam } from "@RmmzPluginSchema/rmmz/plugin";
+import type {
+  ArrayParamTypes,
+  ParamKinds,
+  ScalarParam,
+} from "@RmmzPluginSchema/rmmz/plugin";
 import type { PluginValuesPathBase } from "./base";
 import type { ValueCategory } from "./category";
 import type { StructPropertysPath, StructPathResultWithError } from "./struct";
+import type { TemplateXXX } from "./template";
 
 export interface PluginValuesPath extends PluginValuesPathBase {
   rootCategory: ValueCategory;
   rootName: string;
   scalars?: StructPropertysPath;
+  structs: StructPathResultWithError;
+  structArrays: StructPathResultWithError;
+}
+
+export interface PluginValuesPathEx<
+  Scalar extends ScalarParam,
+  Array extends ArrayParamTypes
+> extends PluginValuesPathBase {
+  rootCategory: ValueCategory;
+  rootName: string;
+  scalars?: TemplateXXX<Scalar, Array>;
   structs: StructPathResultWithError;
   structArrays: StructPathResultWithError;
 }

--- a/src/features/JSONPath/core/createPath/types/bundle.ts
+++ b/src/features/JSONPath/core/createPath/types/bundle.ts
@@ -1,6 +1,5 @@
 import type {
   ArrayParamTypes,
-  ParamKinds,
   ScalarParam,
 } from "@RmmzPluginSchema/rmmz/plugin";
 import type { PluginValuesPathBase } from "./base";
@@ -27,13 +26,14 @@ export interface PluginValuesPathEx<
   structArrays: StructPathResultWithError;
 }
 
-export interface PrimitivePluginValuesPath extends PluginValuesPathBase {
+export interface PrimitivePluginValuesPath<T extends ScalarParam>
+  extends PluginValuesPathBase {
   rootCategory: "param" | "args";
   rootName: string;
   scalars: {
     category: "primitive";
-    name: ParamKinds;
-    objectSchema: Record<string, ScalarParam>;
+    name: T["kind"];
+    objectSchema: Record<string, T>;
     scalarsPath: `$.${string}`;
     scalarArrays: [];
   };

--- a/src/features/JSONPath/core/createPath/types/bundle.ts
+++ b/src/features/JSONPath/core/createPath/types/bundle.ts
@@ -6,7 +6,7 @@ import type {
 import type { PluginValuesPathBase } from "./base";
 import type { ValueCategory } from "./category";
 import type { StructPropertysPath, StructPathResultWithError } from "./struct";
-import type { TemplateXXX } from "./template";
+import type { StructPropertysPathEx3 } from "./template";
 
 export interface PluginValuesPath extends PluginValuesPathBase {
   rootCategory: ValueCategory;
@@ -22,7 +22,7 @@ export interface PluginValuesPathEx<
 > extends PluginValuesPathBase {
   rootCategory: ValueCategory;
   rootName: string;
-  scalars?: TemplateXXX<Scalar, Array>;
+  scalars?: StructPropertysPathEx3<Scalar, Array>;
   structs: StructPathResultWithError;
   structArrays: StructPathResultWithError;
 }

--- a/src/features/JSONPath/core/createPath/types/struct.ts
+++ b/src/features/JSONPath/core/createPath/types/struct.ts
@@ -1,27 +1,17 @@
-import type { ScalarParam } from "@RmmzPluginSchema/rmmz/plugin";
-import type { ArrayParamPathPair } from "./array";
-import type { ValueCategory } from "./category";
+import type {
+  ArrayParamTypes,
+  ScalarParam,
+} from "@RmmzPluginSchema/rmmz/plugin";
 import type { StructPathError } from "./errorTypes";
+import type { TemplateE, TemplateG, TemplateXXX } from "./template";
 
-export interface StructPropertysPath {
-  name: string;
-  category: ValueCategory;
-  scalarsPath: string | undefined;
-  scalarArrays: ArrayParamPathPair[];
-  objectSchema: Record<string, ScalarParam>;
-}
+export type StructPropertysPath = TemplateXXX<ScalarParam, ArrayParamTypes>;
 
 export interface StructPathResultWithError {
   items: StructPropertysPath[];
   errors: StructPathError[];
 }
 
-export interface PluginValuesPathWithError {
-  scalars: StructPropertysPath;
-  structs: StructPathResultWithError;
-  structArrays: StructPathResultWithError;
-}
+export type PluginValuesPathWithError = TemplateE<ScalarParam, ArrayParamTypes>;
 
-export interface StructPathResultItems {
-  items: StructPropertysPath[];
-}
+export type StructPathResultItems = TemplateG<ScalarParam, ArrayParamTypes>;

--- a/src/features/JSONPath/core/createPath/types/struct.ts
+++ b/src/features/JSONPath/core/createPath/types/struct.ts
@@ -2,18 +2,22 @@ import type {
   ArrayParamTypes,
   ScalarParam,
 } from "@RmmzPluginSchema/rmmz/plugin";
-import type { StructPathError } from "./errorTypes";
-import type { TemplateE, TemplateG, StructPropertysPathEx3 } from "./template";
+import type {
+  TemplateE,
+  TemplateG,
+  StructPropertysPathEx3,
+  TemplateGE,
+} from "./template";
 
 export type StructPropertysPath = StructPropertysPathEx3<
   ScalarParam,
   ArrayParamTypes
 >;
 
-export interface StructPathResultWithError {
-  items: StructPropertysPath[];
-  errors: StructPathError[];
-}
+export type StructPathResultWithError = TemplateGE<
+  ScalarParam,
+  ArrayParamTypes
+>;
 
 export type PluginValuesPathWithError = TemplateE<ScalarParam, ArrayParamTypes>;
 

--- a/src/features/JSONPath/core/createPath/types/struct.ts
+++ b/src/features/JSONPath/core/createPath/types/struct.ts
@@ -3,9 +3,12 @@ import type {
   ScalarParam,
 } from "@RmmzPluginSchema/rmmz/plugin";
 import type { StructPathError } from "./errorTypes";
-import type { TemplateE, TemplateG, TemplateXXX } from "./template";
+import type { TemplateE, TemplateG, StructPropertysPathEx3 } from "./template";
 
-export type StructPropertysPath = TemplateXXX<ScalarParam, ArrayParamTypes>;
+export type StructPropertysPath = StructPropertysPathEx3<
+  ScalarParam,
+  ArrayParamTypes
+>;
 
 export interface StructPathResultWithError {
   items: StructPropertysPath[];

--- a/src/features/JSONPath/core/createPath/types/template.ts
+++ b/src/features/JSONPath/core/createPath/types/template.ts
@@ -7,7 +7,7 @@ import type { ArrayParamPathPairEx } from "./array";
 import type { ValueCategory } from "./category";
 import type { StructPathError } from "./errorTypes";
 
-export interface TemplateXXX<
+export interface StructPropertysPathEx3<
   Scalar extends ScalarParam,
   Array extends ArrayParamTypes
 > {
@@ -22,14 +22,14 @@ export interface TemplateG<
   Scalar extends ScalarParam,
   Array extends ArrayParamTypes
 > {
-  items: TemplateXXX<Scalar, Array>[];
+  items: StructPropertysPathEx3<Scalar, Array>[];
 }
 
 export interface TemplateGE<
   Scalar extends ScalarParam,
   Array extends ArrayParamTypes
 > {
-  items: TemplateXXX<Scalar, Array>[];
+  items: StructPropertysPathEx3<Scalar, Array>[];
   errors: StructPathError[];
 }
 
@@ -37,7 +37,7 @@ export interface TemplateE<
   Scalar extends ScalarParam,
   Array extends ArrayParamTypes
 > {
-  scalars: TemplateXXX<Scalar, Array>;
+  scalars: StructPropertysPathEx3<Scalar, Array>;
   structs: TemplateGE<Scalar, Array>;
   structArrays: TemplateGE<Scalar, Array>;
 }

--- a/src/features/JSONPath/core/createPath/types/template.ts
+++ b/src/features/JSONPath/core/createPath/types/template.ts
@@ -1,0 +1,43 @@
+import type {
+  ArrayParamTypes,
+  PluginParamEx,
+  ScalarParam,
+} from "@RmmzPluginSchema/rmmz/plugin";
+import type { ArrayParamPathPairEx } from "./array";
+import type { ValueCategory } from "./category";
+import type { StructPathError } from "./errorTypes";
+
+export interface TemplateXXX<
+  Scalar extends ScalarParam,
+  Array extends ArrayParamTypes
+> {
+  name: string;
+  category: ValueCategory;
+  scalarsPath: string | undefined;
+  scalarArrays: ArrayParamPathPairEx<PluginParamEx<Array>>[];
+  objectSchema: Record<string, Scalar>;
+}
+
+export interface TemplateG<
+  Scalar extends ScalarParam,
+  Array extends ArrayParamTypes
+> {
+  items: TemplateXXX<Scalar, Array>[];
+}
+
+export interface TemplateGE<
+  Scalar extends ScalarParam,
+  Array extends ArrayParamTypes
+> {
+  items: TemplateXXX<Scalar, Array>[];
+  errors: StructPathError[];
+}
+
+export interface TemplateE<
+  Scalar extends ScalarParam,
+  Array extends ArrayParamTypes
+> {
+  scalars: TemplateXXX<Scalar, Array>;
+  structs: TemplateGE<Scalar, Array>;
+  structArrays: TemplateGE<Scalar, Array>;
+}

--- a/src/features/JSONPath/core/createPath/valuePath.test.ts
+++ b/src/features/JSONPath/core/createPath/valuePath.test.ts
@@ -1,14 +1,40 @@
-import { describe, test, expect } from "vitest";
-import type { NumberParam, PluginParamEx } from "@RmmzPluginSchema/rmmz/plugin";
+import type { MockedObject } from "vitest";
+import { describe, test, expect, vi } from "vitest";
+import type {
+  ArrayParamTypes,
+  ClassifiedPluginParamsEx2,
+  NumberArrayParam,
+  NumberParam,
+  PluginParamEx,
+  ScalarParam,
+  StringParam,
+} from "@RmmzPluginSchema/rmmz/plugin";
 import type { PrimitivePluginValuesPath } from "./types";
-import { createPrimiteveParamPath } from "./valuePath";
+import { createPrimiteveParamPath, createPluginValuesPath } from "./valuePath";
+
+const createMockedMap = <
+  S extends ScalarParam,
+  A extends ArrayParamTypes
+>(): MockedObject<ReadonlyMap<string, ClassifiedPluginParamsEx2<S, A>>> => {
+  const map = new Map<string, ClassifiedPluginParamsEx2<S, A>>();
+  return {
+    get: vi.fn((k) => map.get(k)),
+    entries: vi.fn(() => map.entries()),
+    forEach: vi.fn((cb) => map.forEach(cb)),
+    has: vi.fn((k) => map.has(k)),
+    size: map.size,
+    keys: vi.fn(() => map.keys()),
+    values: vi.fn(() => map.values()),
+    [Symbol.iterator]: vi.fn(() => map[Symbol.iterator]()),
+  };
+};
 
 describe("eee", () => {
-  const param: PluginParamEx<NumberParam> = {
-    name: "testParam",
-    attr: { kind: "number", default: 0 },
-  };
-  test("primitive param", () => {
+  describe("", () => {
+    const param: PluginParamEx<NumberParam> = {
+      name: "testParam",
+      attr: { kind: "number", default: 0 },
+    };
     type ResultType = PrimitivePluginValuesPath<NumberParam>;
     const expected: ResultType = {
       rootCategory: "param",
@@ -31,11 +57,60 @@ describe("eee", () => {
         errors: [],
       },
     };
-    const result: ResultType = createPrimiteveParamPath(
-      "param",
-      "testParam",
-      param
-    );
-    expect(result).toEqual(expected);
+    test("number param", () => {
+      const result: ResultType = createPrimiteveParamPath(
+        "param",
+        "testParam",
+        param
+      );
+      expect(result).toEqual(expected);
+    });
+    test("number param via createPluginValuesPath", () => {
+      const structMap = createMockedMap<NumberParam, NumberArrayParam>();
+      const result = createPluginValuesPath(
+        "param",
+        "testParam",
+        param,
+        structMap
+      );
+      expect(result).toEqual(expected);
+      expect(structMap.get).not.toHaveBeenCalled();
+    });
+  });
+  describe("createPrimiteveParamPath with string param", () => {
+    const param: PluginParamEx<StringParam> = {
+      name: "stringParam",
+      attr: { kind: "string", default: "" },
+    };
+    type ResultType = PrimitivePluginValuesPath<StringParam>;
+    const expected: ResultType = {
+      rootCategory: "args",
+      rootName: "stringParam",
+      scalars: {
+        category: "primitive",
+        name: "string",
+        objectSchema: {
+          stringParam: { kind: "string", default: "" },
+        },
+        scalarsPath: "$.stringParam",
+        scalarArrays: [],
+      },
+      structArrays: {
+        items: [],
+        errors: [],
+      },
+      structs: {
+        items: [],
+        errors: [],
+      },
+    };
+    test("string param", () => {
+      const result: ResultType = createPrimiteveParamPath(
+        "args",
+        "stringParam",
+        param
+      );
+      expect(result).toEqual(expected);
+    });
   });
 });

--- a/src/features/JSONPath/core/createPath/valuePath.test.ts
+++ b/src/features/JSONPath/core/createPath/valuePath.test.ts
@@ -1,15 +1,16 @@
 import { describe, test, expect } from "vitest";
-import type { PluginParamEx, ScalarParam } from "@RmmzPluginSchema/rmmz/plugin";
-import type { PluginValuesPathBase, PrimitivePluginValuesPath } from "./types";
+import type { NumberParam, PluginParamEx } from "@RmmzPluginSchema/rmmz/plugin";
+import type { PrimitivePluginValuesPath } from "./types";
 import { createPrimiteveParamPath } from "./valuePath";
 
 describe("eee", () => {
-  const param: PluginParamEx<ScalarParam> = {
+  const param: PluginParamEx<NumberParam> = {
     name: "testParam",
     attr: { kind: "number", default: 0 },
   };
   test("primitive param", () => {
-    const expected: PrimitivePluginValuesPath = {
+    type ResultType = PrimitivePluginValuesPath<NumberParam>;
+    const expected: ResultType = {
       rootCategory: "param",
       rootName: "testParam",
       scalars: {
@@ -30,7 +31,7 @@ describe("eee", () => {
         errors: [],
       },
     };
-    const result: PluginValuesPathBase = createPrimiteveParamPath(
+    const result: ResultType = createPrimiteveParamPath(
       "param",
       "testParam",
       param

--- a/src/features/JSONPath/core/createPath/valuePath.ts
+++ b/src/features/JSONPath/core/createPath/valuePath.ts
@@ -19,6 +19,7 @@ import {
 import type {
   PluginValuesPath,
   PluginValuesPathBase,
+  PluginValuesPathEx,
   PrimitivePluginValuesPath,
 } from "./types";
 
@@ -112,15 +113,18 @@ const createStructPath = (
       items: [],
       errors: [],
     },
-    structs: getPathFromStructParam([param], "$", structMap),
+    structs: getPathFromStructParam(param, "$", structMap),
   };
 };
 
-const createStructArrayPath = (
+const createStructArrayPath = <
+  S extends ScalarParam,
+  A extends ArrayParamTypes
+>(
   category: "param" | "args",
   param: PluginParamEx<StructArrayRefParam>,
   structMap: ReadonlyMap<string, ClassifiedPluginParams>
-): PluginValuesPath => {
+): PluginValuesPathEx<S, A> => {
   return {
     structArrays: getPathFromStructArraySchema([param], "$", structMap),
     rootName: param.name,

--- a/src/features/JSONPath/core/createPath/valuePath.ts
+++ b/src/features/JSONPath/core/createPath/valuePath.ts
@@ -4,7 +4,6 @@ import type {
   ScalarParam,
   StructRefParam,
   StructArrayRefParam,
-  PluginParam,
   ClassifiedPluginParamsEx2,
   ArrayParamItemType2,
 } from "@RmmzPluginSchema/rmmz/plugin";
@@ -25,45 +24,33 @@ export const createPluginValuesPath = <
 >(
   category: "param" | "args",
   rootName: string,
-  param: PluginParam,
+  param: PluginParamEx<S | A | StructRefParam | StructArrayRefParam>,
   structMap: ReadonlyMap<string, ClassifiedPluginParamsEx2<S, A>>
-):
-  | PluginValuesPathEx<S, A>
-  | PrimitivePluginValuesPath<S>
-  | PluginValuesPathEx<ScalarParam, ArrayParamItemType2> => {
+): PluginValuesPathEx<S, A> => {
   if (isStructAttr(param)) {
-    return createStructPath(
-      category,
-      param,
-      structMap
-    ) satisfies PluginValuesPathEx<S, A>;
+    return createStructPath(category, param, structMap);
   }
   if (isStructArrayAttr(param)) {
-    return createStructArrayPath(
-      category,
-      param,
-      structMap
-    ) satisfies PluginValuesPathEx<S, A>;
+    return createStructArrayPath(category, param, structMap);
   }
   if (isArrayAttr(param)) {
-    return createPrimitiveArrayPath(
-      category,
-      rootName,
-      param
-    ) satisfies PluginValuesPathEx<ScalarParam, ArrayParamItemType2>;
+    return createPrimitiveArrayPath<S, A>(category, rootName, param);
   }
-  return createPrimiteveParamPath<ScalarParam>(
+  return createPrimiteveParamPath<S>(
     category,
     rootName,
-    param as PluginParamEx<ScalarParam>
-  ) satisfies PrimitivePluginValuesPath<ScalarParam>;
+    param as PluginParamEx<S>
+  ) satisfies PrimitivePluginValuesPath<S>;
 };
 
-const createPrimitiveArrayPath = <T extends ArrayParamItemType2>(
+const createPrimitiveArrayPath = <
+  S extends ScalarParam,
+  T extends ArrayParamItemType2
+>(
   category: "param" | "args",
   rootName: string,
-  param: PluginParamEx<Exclude<T, StructArrayRefParam>>
-): PluginValuesPathEx<ScalarParam, T> => {
+  param: PluginParamEx<T>
+): PluginValuesPathEx<S, T> => {
   return {
     rootCategory: category,
     rootName: rootName,

--- a/src/features/JSONPath/core/createPath/valuePath.ts
+++ b/src/features/JSONPath/core/createPath/valuePath.ts
@@ -1,12 +1,12 @@
 import type {
   ArrayParamTypes,
-  ClassifiedPluginParams,
   PluginParamEx,
   ScalarParam,
   StructRefParam,
   StructArrayRefParam,
   PluginParam,
   ClassifiedPluginParamsEx2,
+  ArrayParamItemType2,
 } from "@RmmzPluginSchema/rmmz/plugin";
 import {
   isArrayAttr,
@@ -17,35 +17,49 @@ import {
   getPathFromStructArraySchema,
   getPathFromStructParam,
 } from "./structValue";
-import type {
-  PluginValuesPathBase,
-  PluginValuesPathEx,
-  PrimitivePluginValuesPath,
-} from "./types";
+import type { PluginValuesPathEx, PrimitivePluginValuesPath } from "./types";
 
-export const createPluginValuesPath = (
+export const createPluginValuesPath = <
+  S extends ScalarParam,
+  A extends ArrayParamTypes
+>(
   category: "param" | "args",
   rootName: string,
   param: PluginParam,
-  structMap: ReadonlyMap<string, ClassifiedPluginParams>
-): PluginValuesPathBase => {
+  structMap: ReadonlyMap<string, ClassifiedPluginParamsEx2<S, A>>
+):
+  | PluginValuesPathEx<S, A>
+  | PrimitivePluginValuesPath<S>
+  | PluginValuesPathEx<ScalarParam, ArrayParamItemType2> => {
   if (isStructAttr(param)) {
-    return createStructPath(category, param, structMap);
+    return createStructPath(
+      category,
+      param,
+      structMap
+    ) satisfies PluginValuesPathEx<S, A>;
   }
   if (isStructArrayAttr(param)) {
-    return createStructArrayPath(category, param, structMap);
+    return createStructArrayPath(
+      category,
+      param,
+      structMap
+    ) satisfies PluginValuesPathEx<S, A>;
   }
   if (isArrayAttr(param)) {
-    return createPrimitiveArrayPath(category, rootName, param);
+    return createPrimitiveArrayPath(
+      category,
+      rootName,
+      param
+    ) satisfies PluginValuesPathEx<ScalarParam, ArrayParamItemType2>;
   }
-  return createPrimiteveParamPath(
+  return createPrimiteveParamPath<ScalarParam>(
     category,
     rootName,
     param as PluginParamEx<ScalarParam>
-  );
+  ) satisfies PrimitivePluginValuesPath<ScalarParam>;
 };
 
-const createPrimitiveArrayPath = <T extends ArrayParamTypes>(
+const createPrimitiveArrayPath = <T extends ArrayParamItemType2>(
   category: "param" | "args",
   rootName: string,
   param: PluginParamEx<Exclude<T, StructArrayRefParam>>
@@ -99,7 +113,7 @@ export const createStructParamPath = <
   category: "param" | "args",
   param: PluginParamEx<StructRefParam>,
   structMap: ReadonlyMap<string, ClassifiedPluginParamsEx2<S, A>>
-): PluginValuesPathBase => {
+): PluginValuesPathEx<S, A> => {
   return createStructPath(category, param, structMap);
 };
 

--- a/src/features/JSONPath/core/createPath/valuePath.ts
+++ b/src/features/JSONPath/core/createPath/valuePath.ts
@@ -6,6 +6,7 @@ import type {
   StructRefParam,
   StructArrayRefParam,
   PluginParam,
+  ClassifiedPluginParamsEx2,
 } from "@RmmzPluginSchema/rmmz/plugin";
 import {
   isArrayAttr,
@@ -17,7 +18,6 @@ import {
   getPathFromStructParam,
 } from "./structValue";
 import type {
-  PluginValuesPath,
   PluginValuesPathBase,
   PluginValuesPathEx,
   PrimitivePluginValuesPath,
@@ -45,11 +45,11 @@ export const createPluginValuesPath = (
   );
 };
 
-const createPrimitiveArrayPath = (
+const createPrimitiveArrayPath = <T extends ArrayParamTypes>(
   category: "param" | "args",
   rootName: string,
-  param: PluginParamEx<Exclude<ArrayParamTypes, StructArrayRefParam>>
-): PluginValuesPath => {
+  param: PluginParamEx<Exclude<T, StructArrayRefParam>>
+): PluginValuesPathEx<ScalarParam, T> => {
   return {
     rootCategory: category,
     rootName: rootName,
@@ -70,11 +70,11 @@ const createPrimitiveArrayPath = (
   };
 };
 
-export const createPrimiteveParamPath = (
+export const createPrimiteveParamPath = <T extends ScalarParam>(
   category: "param" | "args",
   rootName: string,
-  param: PluginParamEx<ScalarParam>
-): PrimitivePluginValuesPath => {
+  param: PluginParamEx<T>
+): PrimitivePluginValuesPath<T> => {
   return {
     rootCategory: category,
     rootName: rootName,
@@ -92,19 +92,22 @@ export const createPrimiteveParamPath = (
   };
 };
 
-export const createStructParamPath = (
+export const createStructParamPath = <
+  S extends ScalarParam,
+  A extends ArrayParamTypes
+>(
   category: "param" | "args",
   param: PluginParamEx<StructRefParam>,
-  structMap: ReadonlyMap<string, ClassifiedPluginParams>
+  structMap: ReadonlyMap<string, ClassifiedPluginParamsEx2<S, A>>
 ): PluginValuesPathBase => {
   return createStructPath(category, param, structMap);
 };
 
-const createStructPath = (
+const createStructPath = <S extends ScalarParam, A extends ArrayParamTypes>(
   category: "param" | "args",
   param: PluginParamEx<StructRefParam>,
-  structMap: ReadonlyMap<string, ClassifiedPluginParams>
-): PluginValuesPath => {
+  structMap: ReadonlyMap<string, ClassifiedPluginParamsEx2<S, A>>
+): PluginValuesPathEx<S, A> => {
   return {
     rootName: param.name,
     rootCategory: category,
@@ -123,10 +126,10 @@ const createStructArrayPath = <
 >(
   category: "param" | "args",
   param: PluginParamEx<StructArrayRefParam>,
-  structMap: ReadonlyMap<string, ClassifiedPluginParams>
+  structMap: ReadonlyMap<string, ClassifiedPluginParamsEx2<S, A>>
 ): PluginValuesPathEx<S, A> => {
   return {
-    structArrays: getPathFromStructArraySchema([param], "$", structMap),
+    structArrays: getPathFromStructArraySchema(param, "$", structMap),
     rootName: param.name,
     rootCategory: category,
     scalars: undefined,

--- a/src/features/JSONPath/core/extractor/array.ts
+++ b/src/features/JSONPath/core/extractor/array.ts
@@ -1,0 +1,92 @@
+import type { JSONValue } from "@RmmzPluginSchema/libs/jsonPath";
+import type {
+  ScalarParam,
+  ArrayParamTypes,
+  PluginParamEx,
+  StringArrayParam,
+  NumberArrayParam,
+} from "@RmmzPluginSchema/rmmz/plugin";
+import {
+  isStringArrayParam,
+  isNumberArrayParam,
+} from "@RmmzPluginSchema/rmmz/plugin";
+import type {
+  ExtractorBundle,
+  ArrayPathExtractor,
+  PluginValuesStringArray,
+  PluginValuesNumberArray,
+} from "./types";
+
+export const readArrayValue = <
+  T extends ScalarParam,
+  NA extends ArrayParamTypes,
+  SA extends ArrayParamTypes
+>(
+  bundle: ExtractorBundle<T, NA | SA>,
+  groupName: string,
+  json: JSONValue,
+  path: ArrayPathExtractor<NA>
+): PluginValuesStringArray[] | PluginValuesNumberArray[] => {
+  const values: JSONValue = path.jsonPathJS.find(json);
+  if (!Array.isArray(values)) {
+    return [];
+  }
+  const attr = path.schema.attr;
+  if (isStringArrayParam(attr)) {
+    return sap(
+      bundle,
+      values,
+      groupName,
+      path.schema as PluginParamEx<StringArrayParam>
+    );
+  }
+  if (isNumberArrayParam(attr)) {
+    return nap(
+      bundle,
+      values,
+      groupName,
+      path.schema as PluginParamEx<NumberArrayParam>
+    );
+  }
+  return [];
+};
+
+const nap = (
+  bundle: ExtractorBundle,
+  values: unknown[],
+  groupName: string,
+  schema: PluginParamEx<NumberArrayParam>
+): PluginValuesNumberArray[] => {
+  return values
+    .filter((v) => typeof v === "number")
+    .map(
+      (v): PluginValuesNumberArray => ({
+        roootName: bundle.rootName,
+        rootType: bundle.rootCategory,
+        value: v,
+        category: "struct",
+        name: groupName,
+        param: schema,
+      })
+    );
+};
+
+const sap = (
+  bundle: ExtractorBundle,
+  values: unknown[],
+  groupName: string,
+  schema: PluginParamEx<StringArrayParam>
+): PluginValuesStringArray[] => {
+  return values
+    .filter((v) => typeof v === "string")
+    .map((v): PluginValuesStringArray => {
+      return {
+        roootName: bundle.rootName,
+        rootType: bundle.rootCategory,
+        value: v,
+        category: "struct",
+        name: groupName,
+        param: schema,
+      };
+    });
+};

--- a/src/features/JSONPath/core/extractor/extractor.ts
+++ b/src/features/JSONPath/core/extractor/extractor.ts
@@ -2,7 +2,6 @@ import type { JSONValue } from "@RmmzPluginSchema/libs/jsonPath";
 import type {
   ScalarParam,
   ArrayParamTypes,
-  PrimitiveParam,
 } from "@RmmzPluginSchema/rmmz/plugin";
 import { readArrayValue } from "./array";
 import { readScalarValue } from "./scalar";

--- a/src/features/JSONPath/core/extractor/scalar.ts
+++ b/src/features/JSONPath/core/extractor/scalar.ts
@@ -1,0 +1,52 @@
+import type {
+  JSONValue,
+  JSONPathReader,
+} from "@RmmzPluginSchema/libs/jsonPath";
+import type {
+  ScalarParam,
+  ArrayParamTypes,
+} from "@RmmzPluginSchema/rmmz/plugin";
+import type { ExtractorBundle, PluginValueScalar } from "./types";
+
+export const readScalarValue = <T extends ScalarParam>(
+  bundle: ExtractorBundle<T, ArrayParamTypes>,
+  structName: string,
+  json: JSONValue,
+  jsonPath: JSONPathReader,
+  record: Record<string, T>
+): PluginValueScalar<T>[] => {
+  return jsonPath
+    .pathSegments(json)
+    .map(({ value, segments }) => {
+      return vex(bundle, structName, value, segments, record);
+    })
+    .filter((v) => v !== null);
+};
+
+const vex = <T extends ScalarParam>(
+  bundle: ExtractorBundle<T>,
+  structName: string,
+  value: JSONValue,
+  segments: (number | string)[],
+  record: Record<string, T>
+): PluginValueScalar<T> | null => {
+  if (typeof value === "object" || value === null) {
+    return null;
+  }
+  const lastSegment = segments[segments.length - 1];
+  if (typeof lastSegment === "number") {
+    return null;
+  }
+  const schema = record[lastSegment];
+  if (!schema) {
+    return null;
+  }
+  return {
+    roootName: bundle.rootName,
+    rootType: bundle.rootCategory,
+    category: "struct",
+    name: structName,
+    value: value,
+    param: { name: lastSegment, attr: schema },
+  };
+};

--- a/src/features/JSONPath/core/extractor/types/array.ts
+++ b/src/features/JSONPath/core/extractor/types/array.ts
@@ -13,18 +13,22 @@ export interface PluginValuesStringArray extends PluginValues {
   param: PluginParamEx<StringArrayParam>;
 }
 
-export interface PluginValuesNumberArray extends PluginValues {
+export interface PluginValuesNumberArray<
+  T extends NumberArrayParam = NumberArrayParam
+> extends PluginValues {
   value: number;
   category: ValueCategory2;
   name: string;
-  param: PluginParamEx<NumberArrayParam>;
+  param: PluginParamEx<T>;
 }
 
 type StringArrayParam = Extract<PrimitiveParam, { default: string[] }>;
 type NumberArrayParam = Extract<PrimitiveParam, { default: number[] }>;
 
-export interface ArrayPathExtractor {
+export interface ArrayPathExtractor<
+  T extends ArrayParamTypes = ArrayParamTypes
+> {
   jsonPathJS: JSONPathReader;
-  schema: PluginParamEx<ArrayParamTypes>;
+  schema: PluginParamEx<T>;
   parentType: string;
 }

--- a/src/features/JSONPath/core/extractor/types/bundle.ts
+++ b/src/features/JSONPath/core/extractor/types/bundle.ts
@@ -1,24 +1,33 @@
 import type { JSONPathReader } from "@RmmzPluginSchema/libs/jsonPath";
-import type { ScalarParam } from "@RmmzPluginSchema/rmmz/plugin";
+import type {
+  ArrayParamTypes,
+  ScalarParam,
+} from "@RmmzPluginSchema/rmmz/plugin";
 import type { ArrayPathExtractor } from "./array";
 import type { ValueCategory2 } from "./result";
 
-export interface PluginValuesPathMemo4<S extends ScalarParam = ScalarParam> {
+export interface PluginValuesPathMemo4<
+  S extends ScalarParam = ScalarParam,
+  A extends ArrayParamTypes = ArrayParamTypes
+> {
   scalar?: ScalarValueExtractor<S>;
-  arrays: ArrayPathExtractor[];
+  arrays: ArrayPathExtractor<A>[];
   bundleName: string;
 }
 
-export interface ScalarValueExtractor<S extends ScalarParam = ScalarParam> {
+export interface ScalarValueExtractor<S extends ScalarParam> {
   jsonPathJS: JSONPathReader;
   record: Record<string, S>;
 }
 
-export interface ExtractorBundle<S extends ScalarParam = ScalarParam> {
+export interface ExtractorBundle<
+  S extends ScalarParam = ScalarParam,
+  A extends ArrayParamTypes = ArrayParamTypes
+> {
   rootName: string;
   rootCategory: ValueCategory2;
 
-  top: PluginValuesPathMemo4<S> | undefined;
-  structs: PluginValuesPathMemo4<S>[];
-  structArrays: PluginValuesPathMemo4<S>[];
+  top: PluginValuesPathMemo4<S, A> | undefined;
+  structs: PluginValuesPathMemo4<S, A>[];
+  structArrays: PluginValuesPathMemo4<S, A>[];
 }

--- a/src/features/JSONPath/core/extractor/types/bundle.ts
+++ b/src/features/JSONPath/core/extractor/types/bundle.ts
@@ -3,22 +3,22 @@ import type { ScalarParam } from "@RmmzPluginSchema/rmmz/plugin";
 import type { ArrayPathExtractor } from "./array";
 import type { ValueCategory2 } from "./result";
 
-export interface PluginValuesPathMemo4 {
-  scalar?: ScalarValueExtractor;
+export interface PluginValuesPathMemo4<S extends ScalarParam = ScalarParam> {
+  scalar?: ScalarValueExtractor<S>;
   arrays: ArrayPathExtractor[];
   bundleName: string;
 }
 
-export interface ScalarValueExtractor {
+export interface ScalarValueExtractor<S extends ScalarParam = ScalarParam> {
   jsonPathJS: JSONPathReader;
-  record: Record<string, ScalarParam>;
+  record: Record<string, S>;
 }
 
-export interface ExtractorBundle {
+export interface ExtractorBundle<S extends ScalarParam = ScalarParam> {
   rootName: string;
   rootCategory: ValueCategory2;
 
-  top: PluginValuesPathMemo4 | undefined;
-  structs: PluginValuesPathMemo4[];
-  structArrays: PluginValuesPathMemo4[];
+  top: PluginValuesPathMemo4<S> | undefined;
+  structs: PluginValuesPathMemo4<S>[];
+  structArrays: PluginValuesPathMemo4<S>[];
 }

--- a/src/features/JSONPath/core/extractor/types/result.ts
+++ b/src/features/JSONPath/core/extractor/types/result.ts
@@ -7,11 +7,11 @@ export type ValueCategory2 =
   | "args"
   | "primitive";
 
-export interface PluginValues {
+export interface PluginValues<P extends PluginParam = PluginParam> {
   rootType: ValueCategory2;
   roootName: string;
   value: number | string | boolean;
   category: ValueCategory2;
   name: string;
-  param: PluginParam;
+  param: P;
 }

--- a/src/features/JSONPath/core/extractor/types/scalar.ts
+++ b/src/features/JSONPath/core/extractor/types/scalar.ts
@@ -1,9 +1,9 @@
 import type { PluginParamEx, ScalarParam } from "@RmmzPluginSchema/rmmz/plugin";
 import type { PluginValues, ValueCategory2 } from "./result";
 
-export interface PluginValueScalar extends PluginValues {
+export interface PluginValueScalar<T extends ScalarParam> extends PluginValues {
   value: number | string | boolean;
   category: ValueCategory2;
   name: string;
-  param: PluginParamEx<ScalarParam>;
+  param: PluginParamEx<T>;
 }

--- a/src/features/JSONPath/core/pathToMemo.ts
+++ b/src/features/JSONPath/core/pathToMemo.ts
@@ -70,11 +70,11 @@ const compileArrayPathExtractor = (
   );
 };
 
-const compileScalarValueExtractor = (
+const compileScalarValueExtractor = <S extends ScalarParam>(
   path: string,
-  schema: Record<string, ScalarParam>,
+  schema: Record<string, S>,
   factoryFn: (path: string) => JSONPathReader
-): ScalarValueExtractor => ({
+): ScalarValueExtractor<S> => ({
   jsonPathJS: factoryFn(path),
   record: schema,
 });

--- a/src/rmmz/plugin/core/params/classify.ts
+++ b/src/rmmz/plugin/core/params/classify.ts
@@ -13,7 +13,7 @@ import type {
   PrimitiveStringParam,
   ClassifiedPluginFileParams,
   ClassifiedTextParams,
-  ClassifiedPluginParamsEx3,
+  ClassifiedPluginParamsEx2,
 } from "./types";
 import {
   isStructParam,
@@ -61,7 +61,7 @@ const classifyPluginParamsCore = <
   arrayPredicate: (
     param: PluginParamEx<ArrayParamTypes>
   ) => param is PluginParamEx<A>
-): ClassifiedPluginParamsEx3<PluginParamEx<T>, PluginParamEx<A>> => {
+): ClassifiedPluginParamsEx2<T, A> => {
   const structs: PluginParamEx<StructRefParam>[] = [];
   const structArrays: PluginParamEx<StructArrayRefParam>[] = [];
   const scalas: PluginParamEx<T>[] = [];

--- a/src/rmmz/plugin/core/params/classify.ts
+++ b/src/rmmz/plugin/core/params/classify.ts
@@ -10,10 +10,10 @@ import type {
   PluginParam,
   FileParam,
   FileArrayParam,
-  ClassifiedPluginParamsEx2,
   PrimitiveStringParam,
   ClassifiedPluginFileParams,
   ClassifiedTextParams,
+  ClassifiedPluginParamsEx3,
 } from "./types";
 import {
   isStructParam,
@@ -61,7 +61,7 @@ const classifyPluginParamsCore = <
   arrayPredicate: (
     param: PluginParamEx<ArrayParamTypes>
   ) => param is PluginParamEx<A>
-): ClassifiedPluginParamsEx2<T, A> => {
+): ClassifiedPluginParamsEx3<PluginParamEx<T>, PluginParamEx<A>> => {
   const structs: PluginParamEx<StructRefParam>[] = [];
   const structArrays: PluginParamEx<StructArrayRefParam>[] = [];
   const scalas: PluginParamEx<T>[] = [];

--- a/src/rmmz/plugin/core/params/convert.ts
+++ b/src/rmmz/plugin/core/params/convert.ts
@@ -17,10 +17,10 @@ export function toObjectPluginParamsOld(
   return Object.fromEntries(e);
 }
 
-export function toObjectPluginParams(
-  params: ReadonlyArray<PluginParamEx<ScalarParam>>
-): Record<string, ScalarParam> {
-  const e = params.map((p): [string, ScalarParam] => [p.name, p.attr]);
+export function toObjectPluginParams<S extends ScalarParam>(
+  params: ReadonlyArray<PluginParamEx<S>>
+): Record<string, S> {
+  const e = params.map((p): [string, S] => [p.name, p.attr]);
   return Object.fromEntries(e);
 }
 

--- a/src/rmmz/plugin/core/params/types/classifyTypes.ts
+++ b/src/rmmz/plugin/core/params/types/classifyTypes.ts
@@ -29,16 +29,6 @@ export interface ClassifiedPluginParamsEx2<
   scalarArrays: PluginParamEx<A>[];
 }
 
-export interface ClassifiedPluginParamsEx3<
-  S extends PluginParamEx<ScalarParam>,
-  A extends PluginParamEx<ArrayParamTypes>
-> extends ScalaStruct {
-  structs: PluginParamEx<StructRefParam>[];
-  structArrays: PluginParamEx<StructArrayRefParam>[];
-  scalars: S[];
-  scalarArrays: A[];
-}
-
 export type ParamTypesEx4<T, Attr extends PrimitiveParam> = Extract<
   PluginStructParamTypeEx<T>,
   { attr: Attr; name: string }

--- a/src/rmmz/plugin/core/params/types/classifyTypes.ts
+++ b/src/rmmz/plugin/core/params/types/classifyTypes.ts
@@ -29,6 +29,16 @@ export interface ClassifiedPluginParamsEx2<
   scalarArrays: PluginParamEx<A>[];
 }
 
+export interface ClassifiedPluginParamsEx3<
+  S extends PluginParamEx<ScalarParam>,
+  A extends PluginParamEx<ArrayParamTypes>
+> extends ScalaStruct {
+  structs: PluginParamEx<StructRefParam>[];
+  structArrays: PluginParamEx<StructArrayRefParam>[];
+  scalars: S[];
+  scalarArrays: A[];
+}
+
 export type ParamTypesEx4<T, Attr extends PrimitiveParam> = Extract<
   PluginStructParamTypeEx<T>,
   { attr: Attr; name: string }

--- a/src/rmmz/plugin/core/params/types/classifyTypes.ts
+++ b/src/rmmz/plugin/core/params/types/classifyTypes.ts
@@ -22,7 +22,7 @@ export interface ClassifiedPluginParams extends ScalaStruct {
 export interface ClassifiedPluginParamsEx2<
   S extends ScalarParam,
   A extends ArrayParamTypes
-> extends ScalaStruct {
+> extends ClassifiedPluginParams {
   structs: PluginParamEx<StructRefParam>[];
   structArrays: PluginParamEx<StructArrayRefParam>[];
   scalars: PluginParamEx<S>[];
@@ -34,9 +34,13 @@ export type ParamTypesEx4<T, Attr extends PrimitiveParam> = Extract<
   { attr: Attr; name: string }
 >;
 
-export interface ClassifiedPluginParamsEx<T> extends ClassifiedPluginParams {
+export type ClassifiedPluginParamsEx<
+  T,
+  S extends ScalarParam = ScalarParam,
+  A extends ArrayParamTypes = ArrayParamTypes
+> = ClassifiedPluginParamsEx2<S, A> & {
   structs: ParamTypesEx4<T, StructRefParam>[];
   structArrays: ParamTypesEx4<T, StructArrayRefParam>[];
   scalars: ParamTypesEx4<T, ScalarParam>[];
   scalarArrays: ParamTypesEx4<T, ArrayParamTypes>[];
-}
+};

--- a/src/rmmz/plugin/core/params/types/paramUnion.ts
+++ b/src/rmmz/plugin/core/params/types/paramUnion.ts
@@ -68,6 +68,11 @@ export type ScalarParam = Exclude<
 
 export type ArrayParamTypes = Extract<PrimitiveParam, ArrayParam>;
 
+export type ArrayParamItemType2 = Exclude<
+  ArrayParamTypes,
+  { default: object[] }
+>;
+
 // 各パラメータ型のユニオン
 export type StructParam =
   | PrimitiveParam


### PR DESCRIPTION
抽出結果でテンプレートをフル活用するために修正。影響範囲が広すぎるので、一度コミットして中断