### PR TITLE
ParseDefaultValue

### DIFF
--- a/src/rmmz/plugin/core/attributes.boolean.test.ts
+++ b/src/rmmz/plugin/core/attributes.boolean.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import type { ParamSoruceRecord } from "./attributes";
 import { compileAttributes } from "./attributes";
 import type { BooleanParam } from "./params";
@@ -13,12 +13,14 @@ describe("compileAttributes - boolean", () => {
         default: "true",
       } satisfies ParamSoruceRecord<BooleanParam>,
     };
-    const result = compileAttributes(tokens);
+    const fn = vi.fn(() => {});
+    const result = compileAttributes(tokens, fn);
     const expected: BooleanParam = {
       default: true,
       kind: "boolean",
     };
     expect(result).toEqual(expected);
+    expect(fn).not.toHaveBeenCalled();
   });
 
   test("full set", () => {
@@ -34,7 +36,8 @@ describe("compileAttributes - boolean", () => {
         parent: "Parent Feature",
       } satisfies ParamSoruceRecord<BooleanParam>,
     };
-    const result = compileAttributes(tokens);
+    const fn = vi.fn(() => {});
+    const result = compileAttributes(tokens, fn);
     const expected: BooleanParam = {
       default: false,
       text: "Enabled?",
@@ -45,5 +48,6 @@ describe("compileAttributes - boolean", () => {
       kind: "boolean",
     };
     expect(result).toEqual(expected);
+    expect(fn).not.toHaveBeenCalled();
   });
 });

--- a/src/rmmz/plugin/core/attributes.dataId.test.ts
+++ b/src/rmmz/plugin/core/attributes.dataId.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import type { ParamSoruceRecord } from "./attributes";
 import { compileAttributes } from "./attributes";
 import type { RpgDataIdParam, PrimitiveParam } from "./params";
@@ -17,6 +17,9 @@ describe("compileAttributes - dataId", () => {
       kind: "enemy",
       default: 0,
     };
-    expect(compileAttributes(mock)).toEqual(expected);
+    const fn = vi.fn(() => {});
+    const result = compileAttributes(mock, fn);
+    expect(result).toEqual(expected);
+    expect(fn).not.toHaveBeenCalled();
   });
 });

--- a/src/rmmz/plugin/core/attributes.file.test.ts
+++ b/src/rmmz/plugin/core/attributes.file.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import type { ParamSoruceRecord } from "./attributes";
 import { compileAttributes } from "./attributes";
 import type { FileParam, FileArrayParam } from "./params";
@@ -13,13 +13,15 @@ describe("compileAttributes - file", () => {
         default: "path/to/file.txt",
       } satisfies ParamSoruceRecord<FileParam>,
     };
-    const result = compileAttributes(tokens);
+    const fn = vi.fn(() => {});
+    const result = compileAttributes(tokens, fn);
     const expected: FileParam = {
       kind: "file",
       default: "path/to/file.txt",
       dir: "",
     };
     expect(result).toEqual(expected);
+    expect(fn).not.toHaveBeenCalled();
   });
 
   test("full set", () => {
@@ -34,8 +36,9 @@ describe("compileAttributes - file", () => {
         dir: "img",
       } satisfies ParamSoruceRecord<FileParam>,
     };
+    const fn = vi.fn(() => {});
 
-    const result = compileAttributes(tokens);
+    const result = compileAttributes(tokens, fn);
     const expected: FileParam = {
       kind: "file",
       default: "path/to/file.txt",
@@ -45,6 +48,7 @@ describe("compileAttributes - file", () => {
       dir: "img",
     };
     expect(result).toEqual(expected);
+    expect(fn).not.toHaveBeenCalled();
   });
 });
 

--- a/src/rmmz/plugin/core/attributes.number.test.ts
+++ b/src/rmmz/plugin/core/attributes.number.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from "vitest";
+import { describe, test, expect, vi } from "vitest";
 import { compileAttributes } from "./attributes";
 import type { ParamSoruceRecord } from "./attributes";
 import type { NumberParam, NumberArrayParam } from "./params";
@@ -13,12 +13,15 @@ describe("compileAttributes - number", () => {
       } satisfies ParamSoruceRecord<NumberParam>,
     };
 
+    const fn = vi.fn(() => {});
     const expected: NumberParam = {
       kind: "number",
       default: 0,
     };
-    const result = compileAttributes(token);
+
+    const result = compileAttributes(token, fn);
     expect(result).toEqual(expected);
+    expect(fn).not.toHaveBeenCalled();
   });
 
   test("with default", () => {
@@ -29,12 +32,14 @@ describe("compileAttributes - number", () => {
         default: "123.45",
       } satisfies ParamSoruceRecord<NumberParam>,
     };
+    const fn = vi.fn(() => {});
     const expected: NumberParam = {
       kind: "number",
       default: 123.45,
     };
-    const result = compileAttributes(token);
+    const result = compileAttributes(token, fn);
     expect(result).toEqual(expected);
+    expect(fn).not.toHaveBeenCalled();
   });
   test("with all properties", () => {
     const token: PluginParamTokens = {
@@ -59,8 +64,10 @@ describe("compileAttributes - number", () => {
       min: -1000.5,
       max: 1000.5,
     };
-    const result = compileAttributes(token);
+    const fn = vi.fn(() => {});
+    const result = compileAttributes(token, fn);
     expect(result).toEqual(expected);
+    expect(fn).not.toHaveBeenCalled();
   });
 });
 
@@ -77,8 +84,10 @@ describe("compileAttributes - number[]", () => {
       kind: "number[]",
       default: [],
     };
-    const result = compileAttributes(token);
+    const fn = vi.fn(() => {});
+    const result = compileAttributes(token, fn);
     expect(result).toEqual(expected);
+    expect(fn).not.toHaveBeenCalled();
   });
   test("with default", () => {
     const token: PluginParamTokens = {
@@ -92,8 +101,10 @@ describe("compileAttributes - number[]", () => {
       kind: "number[]",
       default: [1, 2, 3],
     };
-    const result = compileAttributes(token);
+    const fn = vi.fn(() => {});
+    const result = compileAttributes(token, fn);
     expect(result).toEqual(expected);
+    expect(fn).not.toHaveBeenCalled();
   });
 
   test("with empty array", () => {
@@ -108,8 +119,10 @@ describe("compileAttributes - number[]", () => {
       kind: "number[]",
       default: [],
     };
-    const result = compileAttributes(token);
+    const fn = vi.fn(() => {});
+    const result = compileAttributes(token, fn);
     expect(result).toEqual(expected);
+    expect(fn).not.toHaveBeenCalled();
   });
   test("with all properties", () => {
     const token: PluginParamTokens = {
@@ -134,7 +147,9 @@ describe("compileAttributes - number[]", () => {
       max: 1000.5,
       decimals: 2,
     };
+    const fn = vi.fn(() => {});
     const result = compileAttributes(token);
     expect(result).toEqual(expected);
+    expect(fn).not.toHaveBeenCalled();
   });
 });

--- a/src/rmmz/plugin/core/attributes.option.test.ts
+++ b/src/rmmz/plugin/core/attributes.option.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from "vitest";
+import { describe, test, expect, vi } from "vitest";
 import { compileAttributes, type ParamSoruceRecord } from "./attributes";
 import type { ComboParam, SelectParam } from "./params";
 import type { PluginParamTokens } from "./parse";
@@ -23,8 +23,10 @@ describe("compileAttributes - combo", () => {
       desc: "this is a combo",
       parent: "parentId",
     };
-    const result = compileAttributes(token);
+    const fn = vi.fn(() => {});
+    const result = compileAttributes(token, fn);
     expect(result).toEqual(expected);
+    expect(fn).not.toHaveBeenCalled();
   });
   test("with options", () => {
     const token: PluginParamTokens = {
@@ -49,8 +51,10 @@ describe("compileAttributes - combo", () => {
       desc: "this is a combo",
       parent: "parentId",
     };
-    const result = compileAttributes(token);
+    const fn = vi.fn(() => {});
+    const result = compileAttributes(token, fn);
     expect(result).toEqual(expected);
+    expect(fn).not.toHaveBeenCalled();
   });
 });
 
@@ -75,8 +79,10 @@ describe("compileAttributes - select", () => {
       desc: "this is a select",
       parent: "parentId",
     };
-    const result = compileAttributes(token);
+    const fn = vi.fn(() => {});
+    const result = compileAttributes(token, fn);
     expect(result).toEqual(expected);
+    expect(fn).not.toHaveBeenCalled();
   });
   test("with options", () => {
     const token: PluginParamTokens = {
@@ -105,7 +111,9 @@ describe("compileAttributes - select", () => {
       desc: "this is a select",
       parent: "parentId",
     };
-    const result = compileAttributes(token);
+    const fn = vi.fn(() => {});
+    const result = compileAttributes(token, fn);
     expect(result).toEqual(expected);
+    expect(fn).not.toHaveBeenCalled();
   });
 });

--- a/src/rmmz/plugin/core/attributes.string.test.ts
+++ b/src/rmmz/plugin/core/attributes.string.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import type { ParamSoruceRecord } from "./attributes";
 import { compileAttributes } from "./attributes";
 import type { StringParam, StringArrayParam } from "./params";
@@ -17,8 +17,10 @@ describe("compileAttributes - string", () => {
       kind: "string",
       default: "abc",
     };
-    const result = compileAttributes(tokens);
+    const fn = vi.fn(() => {});
+    const result = compileAttributes(tokens, fn);
     expect(result).toEqual(expected);
+    expect(fn).not.toHaveBeenCalled();
   });
 
   test("full set", () => {
@@ -39,8 +41,10 @@ describe("compileAttributes - string", () => {
       desc: "String Description",
       parent: "Parent String",
     };
-    const result = compileAttributes(tokens);
+    const fn = vi.fn(() => {});
+    const result = compileAttributes(tokens, fn);
     expect(result).toEqual(expected);
+    expect(fn).not.toHaveBeenCalled();
   });
 });
 
@@ -57,8 +61,11 @@ describe("compileAttributes - string[]", () => {
       kind: "string[]",
       default: ["a", "b", "c"],
     };
-    const result = compileAttributes(tokens);
+    const fn = vi.fn(() => {});
+
+    const result = compileAttributes(tokens, fn);
     expect(result).toEqual(expected);
+    expect(fn).not.toHaveBeenCalled();
   });
 
   test("empty array", () => {
@@ -73,7 +80,9 @@ describe("compileAttributes - string[]", () => {
       kind: "string[]",
       default: [],
     };
-    const result = compileAttributes(tokens);
+    const fn = vi.fn(() => {});
+    const result = compileAttributes(tokens, fn);
     expect(result).toEqual(expected);
+    expect(fn).not.toHaveBeenCalled();
   });
 });

--- a/src/rmmz/plugin/core/attributes.ts
+++ b/src/rmmz/plugin/core/attributes.ts
@@ -1,3 +1,4 @@
+import { createDefaultStruct, createDefaultStructArray } from "./defaultStruct";
 import type { MappingTable } from "./mapping/mapping";
 import { compileParam, compileArrayParam } from "./mapping/mapping";
 import type {
@@ -26,12 +27,19 @@ type MappingTableEx<T> = MappingTable<Omit<T, "kind">>;
 export type ParamSoruceRecord<T> = Partial<Record<keyof T, string>>;
 
 export const compileAttributes = (
-  tokens: PluginParamTokens
+  tokens: PluginParamTokens,
+  objectParseFn: (json: string) => unknown = parseDeepJSON
 ): PrimitiveParam => {
   if (KEYWORD_KIND in tokens.attr) {
     const func = TABLE2[tokens.attr.kind as keyof typeof TABLE2];
     if (func) {
       return func(tokens);
+    }
+    if (tokens.attr.kind === "struct") {
+      return compileStructParam2(tokens, objectParseFn);
+    }
+    if (tokens.attr.kind === "struct[]") {
+      return compileStructArrayParam2(tokens, objectParseFn);
     }
   }
   return compileParam("any", "", tokens.attr, STRING);
@@ -187,22 +195,11 @@ const compileDataId = <Kind extends DataKind_RpgUnion | DataKind_SystemUnion>(
   return compileParam(kind, 0, tokens.attr, DATA_ID);
 };
 
-const createDefaultStruct = (tokens: PluginParamTokens) => {
-  if (!tokens.attr.default) {
-    return {};
-  }
-  const value = parseDeepJSON(tokens.attr.default);
-  if (Array.isArray(value)) {
-    return {};
-  }
-  if (typeof value === "object" && value !== null) {
-    return value;
-  }
-  return {};
-};
-
-const compileStructParam = (tokens: PluginParamTokens): StructRefParam => {
-  const defaultValue: Record<string, unknown> = createDefaultStruct(tokens);
+const compileStructParam2 = (
+  tokens: PluginParamTokens,
+  fn: (deepJSON: string) => unknown
+): StructRefParam => {
+  const defaultValue = createDefaultStruct(tokens.attr.default, fn);
   const STRUCT_REF = {
     text: attrString,
     desc: attrString,
@@ -214,23 +211,14 @@ const compileStructParam = (tokens: PluginParamTokens): StructRefParam => {
   };
 };
 
-const createDefaultStructArray = (tokens: PluginParamTokens) => {
-  if (!tokens.attr.default) {
-    return [];
-  }
-  const value = parseDeepJSON(tokens.attr.default);
-  if (Array.isArray(value)) {
-    if (value.every((v) => typeof v === "object" && v !== null)) {
-      return value;
-    }
-  }
-  return [];
-};
-
-const compileStructArrayParam = (
-  tokens: PluginParamTokens
+const compileStructArrayParam2 = (
+  tokens: PluginParamTokens,
+  objectParseFn: (json: string) => unknown
 ): StructArrayRefParam => {
-  const defaultValue = createDefaultStructArray(tokens);
+  const defaultValue = createDefaultStructArray(
+    tokens.attr.default,
+    objectParseFn
+  );
   const STRUCT_ARRAY = {
     text: attrString,
     desc: attrString,
@@ -279,8 +267,6 @@ const TABLE2 = {
   boolean: compileBooleanParam,
   file: compileFileParam,
   "file[]": compileFileArrayParam,
-  struct: compileStructParam,
-  "struct[]": compileStructArrayParam,
 } as const satisfies Partial<{
-  [K in PrimitiveParam["kind"]]: (tokens: PluginParamTokens) => PrimitiveParam;
+  [K in PrimitiveParam["kind"]]?: (tokens: PluginParamTokens) => PrimitiveParam;
 }>;

--- a/src/rmmz/plugin/core/compilePluginAsArraySchema.ts
+++ b/src/rmmz/plugin/core/compilePluginAsArraySchema.ts
@@ -11,44 +11,58 @@ import type {
   PluginCommandTokens,
   StructParseState,
 } from "./parse/types";
+import { parseDeepJSON } from "./rmmzJSON";
+
+export type CCC = "command" | "param" | "struct";
 
 export const compilePluginAsArraySchema = (
-  parsedPlugin: PluginTokens
+  parsedPlugin: PluginTokens,
+  fn: (structDefault: string, category: CCC) => unknown = (s: string) =>
+    parseDeepJSON(s)
 ): PluginSchemaArray => ({
-  commands: mapCommands(parsedPlugin.commands),
-  params: mapParams(parsedPlugin.params),
-  structs: mapStructs(parsedPlugin.structs),
+  params: mapParams(parsedPlugin.params, (text: string) => fn(text, "param")),
+  commands: mapCommands(parsedPlugin.commands, (text: string) =>
+    fn(text, "command")
+  ),
+  structs: mapStructs(parsedPlugin.structs, (text: string) =>
+    fn(text, "struct")
+  ),
 });
 
-const mapParams = (params: ReadonlyArray<PluginParamTokens>): PluginParam[] => {
+const mapParams = (
+  params: ReadonlyArray<PluginParamTokens>,
+  fn: (structDefault: string) => unknown
+): PluginParam[] => {
   return params.map(
     (p): PluginParam => ({
       name: p.name,
-      attr: compileAttributes(p),
+      attr: compileAttributes(p, fn),
     })
   );
 };
 
 const mapCommands = (
-  commands: ReadonlyArray<PluginCommandTokens>
+  commands: ReadonlyArray<PluginCommandTokens>,
+  fn: (structDefault: string) => unknown
 ): PluginCommandSchemaArray[] => {
   return commands.map(
     (cmd): PluginCommandSchemaArray => ({
       command: cmd.command,
       desc: cmd.desc,
       text: cmd.text,
-      args: mapParams(cmd.args),
+      args: mapParams(cmd.args, fn),
     })
   );
 };
 
 const mapStructs = (
-  structs: ReadonlyArray<StructParseState>
+  structs: ReadonlyArray<StructParseState>,
+  fn: (structDefault: string) => unknown
 ): PluginStructSchemaArray[] => {
   return structs.map(
     (s): PluginStructSchemaArray => ({
       struct: s.name,
-      params: mapParams(s.params),
+      params: mapParams(s.params, fn),
     })
   );
 };

--- a/src/rmmz/plugin/core/defaultStruct.ts
+++ b/src/rmmz/plugin/core/defaultStruct.ts
@@ -1,0 +1,32 @@
+export const createDefaultStruct = (
+  defaultValue: string | undefined,
+  fn: (deepJSON: string) => unknown
+): object => {
+  if (!defaultValue) {
+    return {};
+  }
+  const value = fn(defaultValue);
+  if (Array.isArray(value)) {
+    return {};
+  }
+  if (typeof value === "object" && value !== null) {
+    return value;
+  }
+  return {};
+};
+
+export const createDefaultStructArray = (
+  defaultValue: string | undefined,
+  fn: (deepJSON: string) => unknown
+): object[] => {
+  if (!defaultValue) {
+    return [];
+  }
+  const value = fn(defaultValue);
+  if (Array.isArray(value)) {
+    if (value.every((v) => typeof v === "object" && v !== null)) {
+      return value;
+    }
+  }
+  return [];
+};


### PR DESCRIPTION
デフォルト値の文字列を解析する時にエラーを起こしがちなので、コールバックに移譲するようにした。どこまで改善できるかは不明