### PR TITLE
DefaultValueHandlers

### DIFF
--- a/src/rmmz/plugin/core/attributes.any.test.ts
+++ b/src/rmmz/plugin/core/attributes.any.test.ts
@@ -1,8 +1,16 @@
-import { describe, expect, test } from "vitest";
+import type { MockedObject } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import type { ParamSoruceRecord } from "./attributes";
 import { compileAttributes } from "./attributes";
 import type { AnyStringParam } from "./params";
 import type { PluginParamTokens } from "./parse/types/types";
+import type { DeepJSONParserHandlers } from "./rmmzJSON/types/handlers";
+
+const createHandlers = (): MockedObject<DeepJSONParserHandlers> => ({
+  parseStringArray: vi.fn(),
+  parseObject: vi.fn(),
+  parseObjectArray: vi.fn(),
+});
 
 describe("compileAttributes - any", () => {
   test("no kind", () => {
@@ -16,8 +24,12 @@ describe("compileAttributes - any", () => {
       kind: "any",
       default: "",
     };
-    const result = compileAttributes(tokens);
+    const mockHandlers = createHandlers();
+    const result = compileAttributes(tokens, mockHandlers);
     expect(result).toEqual(expected);
+    expect(mockHandlers.parseStringArray).not.toHaveBeenCalled();
+    expect(mockHandlers.parseObject).not.toHaveBeenCalled();
+    expect(mockHandlers.parseObjectArray).not.toHaveBeenCalled();
   });
   test("unknown kind", () => {
     const tokens: PluginParamTokens = {
@@ -30,7 +42,11 @@ describe("compileAttributes - any", () => {
       kind: "any",
       default: "",
     };
-    const result = compileAttributes(tokens);
+    const mockHandlers = createHandlers();
+    const result = compileAttributes(tokens, mockHandlers);
     expect(result).toEqual(expected);
+    expect(mockHandlers.parseStringArray).not.toHaveBeenCalled();
+    expect(mockHandlers.parseObject).not.toHaveBeenCalled();
+    expect(mockHandlers.parseObjectArray).not.toHaveBeenCalled();
   });
 });

--- a/src/rmmz/plugin/core/attributes.boolean.test.ts
+++ b/src/rmmz/plugin/core/attributes.boolean.test.ts
@@ -1,8 +1,16 @@
+import type { MockedObject } from "vitest";
 import { describe, expect, test, vi } from "vitest";
 import type { ParamSoruceRecord } from "./attributes";
 import { compileAttributes } from "./attributes";
 import type { BooleanParam } from "./params";
 import type { PluginParamTokens } from "./parse";
+import type { DeepJSONParserHandlers } from "./rmmzJSON/types/handlers";
+
+const createHandlers = (): MockedObject<DeepJSONParserHandlers> => ({
+  parseStringArray: vi.fn(),
+  parseObject: vi.fn(),
+  parseObjectArray: vi.fn(),
+});
 
 describe("compileAttributes - boolean", () => {
   test("minimum set", () => {
@@ -13,14 +21,16 @@ describe("compileAttributes - boolean", () => {
         default: "true",
       } satisfies ParamSoruceRecord<BooleanParam>,
     };
-    const fn = vi.fn(() => {});
-    const result = compileAttributes(tokens, fn);
+    const mockHandlers = createHandlers();
+    const result = compileAttributes(tokens, mockHandlers);
     const expected: BooleanParam = {
       default: true,
       kind: "boolean",
     };
     expect(result).toEqual(expected);
-    expect(fn).not.toHaveBeenCalled();
+    expect(mockHandlers.parseStringArray).not.toHaveBeenCalled();
+    expect(mockHandlers.parseObject).not.toHaveBeenCalled();
+    expect(mockHandlers.parseObjectArray).not.toHaveBeenCalled();
   });
 
   test("full set", () => {
@@ -36,8 +46,8 @@ describe("compileAttributes - boolean", () => {
         parent: "Parent Feature",
       } satisfies ParamSoruceRecord<BooleanParam>,
     };
-    const fn = vi.fn(() => {});
-    const result = compileAttributes(tokens, fn);
+    const mockHandlers = createHandlers();
+    const result = compileAttributes(tokens, mockHandlers);
     const expected: BooleanParam = {
       default: false,
       text: "Enabled?",
@@ -48,6 +58,8 @@ describe("compileAttributes - boolean", () => {
       kind: "boolean",
     };
     expect(result).toEqual(expected);
-    expect(fn).not.toHaveBeenCalled();
+    expect(mockHandlers.parseStringArray).not.toHaveBeenCalled();
+    expect(mockHandlers.parseObject).not.toHaveBeenCalled();
+    expect(mockHandlers.parseObjectArray).not.toHaveBeenCalled();
   });
 });

--- a/src/rmmz/plugin/core/attributes.dataId.test.ts
+++ b/src/rmmz/plugin/core/attributes.dataId.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from "vitest";
+import { describe, expect, test } from "vitest";
 import type { ParamSoruceRecord } from "./attributes";
 import { compileAttributes } from "./attributes";
 import type { RpgDataIdParam, PrimitiveParam } from "./params";
@@ -17,9 +17,7 @@ describe("compileAttributes - dataId", () => {
       kind: "enemy",
       default: 0,
     };
-    const fn = vi.fn(() => {});
-    const result = compileAttributes(mock, fn);
+    const result = compileAttributes(mock);
     expect(result).toEqual(expected);
-    expect(fn).not.toHaveBeenCalled();
   });
 });

--- a/src/rmmz/plugin/core/attributes.file.test.ts
+++ b/src/rmmz/plugin/core/attributes.file.test.ts
@@ -1,8 +1,16 @@
+import type { MockedObject } from "vitest";
 import { describe, expect, test, vi } from "vitest";
 import type { ParamSoruceRecord } from "./attributes";
 import { compileAttributes } from "./attributes";
 import type { FileParam, FileArrayParam } from "./params";
 import type { PluginParamTokens } from "./parse";
+import type { DeepJSONParserHandlers } from "./rmmzJSON/types/handlers";
+
+const createHandlers = (): MockedObject<DeepJSONParserHandlers> => ({
+  parseStringArray: vi.fn(),
+  parseObject: vi.fn(),
+  parseObjectArray: vi.fn(),
+});
 
 describe("compileAttributes - file", () => {
   test("minimum set", () => {
@@ -13,15 +21,17 @@ describe("compileAttributes - file", () => {
         default: "path/to/file.txt",
       } satisfies ParamSoruceRecord<FileParam>,
     };
-    const fn = vi.fn(() => {});
-    const result = compileAttributes(tokens, fn);
+    const mockHandlers = createHandlers();
+    const result = compileAttributes(tokens, mockHandlers);
     const expected: FileParam = {
       kind: "file",
       default: "path/to/file.txt",
       dir: "",
     };
     expect(result).toEqual(expected);
-    expect(fn).not.toHaveBeenCalled();
+    expect(mockHandlers.parseStringArray).not.toHaveBeenCalled();
+    expect(mockHandlers.parseObject).not.toHaveBeenCalled();
+    expect(mockHandlers.parseObjectArray).not.toHaveBeenCalled();
   });
 
   test("full set", () => {
@@ -36,9 +46,9 @@ describe("compileAttributes - file", () => {
         dir: "img",
       } satisfies ParamSoruceRecord<FileParam>,
     };
-    const fn = vi.fn(() => {});
+    const mockHandlers = createHandlers();
 
-    const result = compileAttributes(tokens, fn);
+    const result = compileAttributes(tokens, mockHandlers);
     const expected: FileParam = {
       kind: "file",
       default: "path/to/file.txt",
@@ -48,7 +58,9 @@ describe("compileAttributes - file", () => {
       dir: "img",
     };
     expect(result).toEqual(expected);
-    expect(fn).not.toHaveBeenCalled();
+    expect(mockHandlers.parseStringArray).not.toHaveBeenCalled();
+    expect(mockHandlers.parseObject).not.toHaveBeenCalled();
+    expect(mockHandlers.parseObjectArray).not.toHaveBeenCalled();
   });
 });
 
@@ -62,13 +74,18 @@ describe("compileAttributes - file[]", () => {
       } satisfies ParamSoruceRecord<FileArrayParam>,
     };
 
-    const result = compileAttributes(tokens);
+    const mockHandlers = createHandlers();
+
+    const result = compileAttributes(tokens, mockHandlers);
     const expected: FileArrayParam = {
       kind: "file[]",
       default: ["path/to/file1.txt", "path/to/file2.txt"],
       dir: "",
     };
     expect(result).toEqual(expected);
+    expect(mockHandlers.parseStringArray).not.toHaveBeenCalled();
+    expect(mockHandlers.parseObject).not.toHaveBeenCalled();
+    expect(mockHandlers.parseObjectArray).not.toHaveBeenCalled();
   });
 
   test("empty array", () => {
@@ -79,13 +96,17 @@ describe("compileAttributes - file[]", () => {
         default: `[]`,
       } satisfies ParamSoruceRecord<FileArrayParam>,
     };
+    const mockHandlers = createHandlers();
 
-    const result = compileAttributes(tokens);
+    const result = compileAttributes(tokens, mockHandlers);
     const expected: FileArrayParam = {
       kind: "file[]",
       default: [],
       dir: "",
     };
     expect(result).toEqual(expected);
+    expect(mockHandlers.parseStringArray).not.toHaveBeenCalled();
+    expect(mockHandlers.parseObject).not.toHaveBeenCalled();
+    expect(mockHandlers.parseObjectArray).not.toHaveBeenCalled();
   });
 });

--- a/src/rmmz/plugin/core/attributes.file.test.ts
+++ b/src/rmmz/plugin/core/attributes.file.test.ts
@@ -2,15 +2,19 @@ import type { MockedObject } from "vitest";
 import { describe, expect, test, vi } from "vitest";
 import type { ParamSoruceRecord } from "./attributes";
 import { compileAttributes } from "./attributes";
+import { createDeepJSONParserHandlers } from "./deepJSONHandler";
 import type { FileParam, FileArrayParam } from "./params";
 import type { PluginParamTokens } from "./parse";
 import type { DeepJSONParserHandlers } from "./rmmzJSON/types/handlers";
 
-const createHandlers = (): MockedObject<DeepJSONParserHandlers> => ({
-  parseStringArray: vi.fn(),
-  parseObject: vi.fn(),
-  parseObjectArray: vi.fn(),
-});
+const createHandlers = (): MockedObject<DeepJSONParserHandlers> => {
+  const parser = createDeepJSONParserHandlers();
+  return {
+    parseStringArray: vi.fn((s: string) => parser.parseStringArray(s)),
+    parseObject: vi.fn((s: string) => parser.parseObject(s)),
+    parseObjectArray: vi.fn((s: string) => parser.parseObjectArray(s)),
+  };
+};
 
 describe("compileAttributes - file", () => {
   test("minimum set", () => {
@@ -83,7 +87,10 @@ describe("compileAttributes - file[]", () => {
       dir: "",
     };
     expect(result).toEqual(expected);
-    expect(mockHandlers.parseStringArray).not.toHaveBeenCalled();
+    expect(mockHandlers.parseStringArray).toHaveBeenCalledWith(
+      tokens.attr.default
+    );
+    expect(mockHandlers.parseStringArray).toHaveBeenCalledTimes(1);
     expect(mockHandlers.parseObject).not.toHaveBeenCalled();
     expect(mockHandlers.parseObjectArray).not.toHaveBeenCalled();
   });
@@ -105,7 +112,10 @@ describe("compileAttributes - file[]", () => {
       dir: "",
     };
     expect(result).toEqual(expected);
-    expect(mockHandlers.parseStringArray).not.toHaveBeenCalled();
+    expect(mockHandlers.parseStringArray).toHaveBeenCalledWith(
+      tokens.attr.default
+    );
+    expect(mockHandlers.parseStringArray).toHaveBeenCalledTimes(1);
     expect(mockHandlers.parseObject).not.toHaveBeenCalled();
     expect(mockHandlers.parseObjectArray).not.toHaveBeenCalled();
   });

--- a/src/rmmz/plugin/core/attributes.number.test.ts
+++ b/src/rmmz/plugin/core/attributes.number.test.ts
@@ -1,8 +1,16 @@
+import type { MockedObject } from "vitest";
 import { describe, test, expect, vi } from "vitest";
 import { compileAttributes } from "./attributes";
 import type { ParamSoruceRecord } from "./attributes";
 import type { NumberParam, NumberArrayParam } from "./params";
 import type { PluginParamTokens } from "./parse";
+import type { DeepJSONParserHandlers } from "./rmmzJSON/types/handlers";
+
+const createHandlers = (): MockedObject<DeepJSONParserHandlers> => ({
+  parseStringArray: vi.fn(),
+  parseObject: vi.fn(),
+  parseObjectArray: vi.fn(),
+});
 
 describe("compileAttributes - number", () => {
   test("type only", () => {
@@ -13,15 +21,18 @@ describe("compileAttributes - number", () => {
       } satisfies ParamSoruceRecord<NumberParam>,
     };
 
-    const fn = vi.fn(() => {});
+    const mockHandlers = createHandlers();
+
     const expected: NumberParam = {
       kind: "number",
       default: 0,
     };
 
-    const result = compileAttributes(token, fn);
+    const result = compileAttributes(token, mockHandlers);
     expect(result).toEqual(expected);
-    expect(fn).not.toHaveBeenCalled();
+    expect(mockHandlers.parseStringArray).not.toHaveBeenCalled();
+    expect(mockHandlers.parseObject).not.toHaveBeenCalled();
+    expect(mockHandlers.parseObjectArray).not.toHaveBeenCalled();
   });
 
   test("with default", () => {
@@ -32,14 +43,16 @@ describe("compileAttributes - number", () => {
         default: "123.45",
       } satisfies ParamSoruceRecord<NumberParam>,
     };
-    const fn = vi.fn(() => {});
+    const mockHandlers = createHandlers();
     const expected: NumberParam = {
       kind: "number",
       default: 123.45,
     };
-    const result = compileAttributes(token, fn);
+    const result = compileAttributes(token, mockHandlers);
     expect(result).toEqual(expected);
-    expect(fn).not.toHaveBeenCalled();
+    expect(mockHandlers.parseStringArray).not.toHaveBeenCalled();
+    expect(mockHandlers.parseObject).not.toHaveBeenCalled();
+    expect(mockHandlers.parseObjectArray).not.toHaveBeenCalled();
   });
   test("with all properties", () => {
     const token: PluginParamTokens = {
@@ -64,10 +77,12 @@ describe("compileAttributes - number", () => {
       min: -1000.5,
       max: 1000.5,
     };
-    const fn = vi.fn(() => {});
-    const result = compileAttributes(token, fn);
+    const mockHandlers = createHandlers();
+    const result = compileAttributes(token, mockHandlers);
     expect(result).toEqual(expected);
-    expect(fn).not.toHaveBeenCalled();
+    expect(mockHandlers.parseStringArray).not.toHaveBeenCalled();
+    expect(mockHandlers.parseObject).not.toHaveBeenCalled();
+    expect(mockHandlers.parseObjectArray).not.toHaveBeenCalled();
   });
 });
 
@@ -84,10 +99,12 @@ describe("compileAttributes - number[]", () => {
       kind: "number[]",
       default: [],
     };
-    const fn = vi.fn(() => {});
-    const result = compileAttributes(token, fn);
+    const mockHandlers = createHandlers();
+    const result = compileAttributes(token, mockHandlers);
     expect(result).toEqual(expected);
-    expect(fn).not.toHaveBeenCalled();
+    expect(mockHandlers.parseStringArray).not.toHaveBeenCalled();
+    expect(mockHandlers.parseObject).not.toHaveBeenCalled();
+    expect(mockHandlers.parseObjectArray).not.toHaveBeenCalled();
   });
   test("with default", () => {
     const token: PluginParamTokens = {
@@ -101,10 +118,12 @@ describe("compileAttributes - number[]", () => {
       kind: "number[]",
       default: [1, 2, 3],
     };
-    const fn = vi.fn(() => {});
-    const result = compileAttributes(token, fn);
+    const mockHandlers = createHandlers();
+    const result = compileAttributes(token, mockHandlers);
     expect(result).toEqual(expected);
-    expect(fn).not.toHaveBeenCalled();
+    expect(mockHandlers.parseStringArray).not.toHaveBeenCalled();
+    expect(mockHandlers.parseObject).not.toHaveBeenCalled();
+    expect(mockHandlers.parseObjectArray).not.toHaveBeenCalled();
   });
 
   test("with empty array", () => {
@@ -119,10 +138,12 @@ describe("compileAttributes - number[]", () => {
       kind: "number[]",
       default: [],
     };
-    const fn = vi.fn(() => {});
-    const result = compileAttributes(token, fn);
+    const mockHandlers = createHandlers();
+    const result = compileAttributes(token, mockHandlers);
     expect(result).toEqual(expected);
-    expect(fn).not.toHaveBeenCalled();
+    expect(mockHandlers.parseStringArray).not.toHaveBeenCalled();
+    expect(mockHandlers.parseObject).not.toHaveBeenCalled();
+    expect(mockHandlers.parseObjectArray).not.toHaveBeenCalled();
   });
   test("with all properties", () => {
     const token: PluginParamTokens = {
@@ -147,9 +168,11 @@ describe("compileAttributes - number[]", () => {
       max: 1000.5,
       decimals: 2,
     };
-    const fn = vi.fn(() => {});
-    const result = compileAttributes(token);
+    const mockHandlers = createHandlers();
+    const result = compileAttributes(token, mockHandlers);
     expect(result).toEqual(expected);
-    expect(fn).not.toHaveBeenCalled();
+    expect(mockHandlers.parseStringArray).not.toHaveBeenCalled();
+    expect(mockHandlers.parseObject).not.toHaveBeenCalled();
+    expect(mockHandlers.parseObjectArray).not.toHaveBeenCalled();
   });
 });

--- a/src/rmmz/plugin/core/attributes.option.test.ts
+++ b/src/rmmz/plugin/core/attributes.option.test.ts
@@ -1,7 +1,16 @@
+import type { MockedObject } from "vitest";
 import { describe, test, expect, vi } from "vitest";
-import { compileAttributes, type ParamSoruceRecord } from "./attributes";
+import type { ParamSoruceRecord } from "./attributes";
+import { compileAttributes } from "./attributes";
 import type { ComboParam, SelectParam } from "./params";
 import type { PluginParamTokens } from "./parse";
+import type { DeepJSONParserHandlers } from "./rmmzJSON/types/handlers";
+
+const createHandlers = (): MockedObject<DeepJSONParserHandlers> => ({
+  parseStringArray: vi.fn(),
+  parseObject: vi.fn(),
+  parseObjectArray: vi.fn(),
+});
 
 describe("compileAttributes - combo", () => {
   test("empty options", () => {
@@ -23,10 +32,12 @@ describe("compileAttributes - combo", () => {
       desc: "this is a combo",
       parent: "parentId",
     };
-    const fn = vi.fn(() => {});
-    const result = compileAttributes(token, fn);
+    const mockHandlers = createHandlers();
+    const result = compileAttributes(token, mockHandlers);
     expect(result).toEqual(expected);
-    expect(fn).not.toHaveBeenCalled();
+    expect(mockHandlers.parseStringArray).not.toHaveBeenCalled();
+    expect(mockHandlers.parseObject).not.toHaveBeenCalled();
+    expect(mockHandlers.parseObjectArray).not.toHaveBeenCalled();
   });
   test("with options", () => {
     const token: PluginParamTokens = {
@@ -51,10 +62,12 @@ describe("compileAttributes - combo", () => {
       desc: "this is a combo",
       parent: "parentId",
     };
-    const fn = vi.fn(() => {});
-    const result = compileAttributes(token, fn);
+    const mockHandlers = createHandlers();
+    const result = compileAttributes(token, mockHandlers);
     expect(result).toEqual(expected);
-    expect(fn).not.toHaveBeenCalled();
+    expect(mockHandlers.parseStringArray).not.toHaveBeenCalled();
+    expect(mockHandlers.parseObject).not.toHaveBeenCalled();
+    expect(mockHandlers.parseObjectArray).not.toHaveBeenCalled();
   });
 });
 
@@ -79,10 +92,12 @@ describe("compileAttributes - select", () => {
       desc: "this is a select",
       parent: "parentId",
     };
-    const fn = vi.fn(() => {});
-    const result = compileAttributes(token, fn);
+    const mockHandlers = createHandlers();
+    const result = compileAttributes(token, mockHandlers);
     expect(result).toEqual(expected);
-    expect(fn).not.toHaveBeenCalled();
+    expect(mockHandlers.parseStringArray).not.toHaveBeenCalled();
+    expect(mockHandlers.parseObject).not.toHaveBeenCalled();
+    expect(mockHandlers.parseObjectArray).not.toHaveBeenCalled();
   });
   test("with options", () => {
     const token: PluginParamTokens = {
@@ -111,9 +126,11 @@ describe("compileAttributes - select", () => {
       desc: "this is a select",
       parent: "parentId",
     };
-    const fn = vi.fn(() => {});
-    const result = compileAttributes(token, fn);
+    const mockHandlers = createHandlers();
+    const result = compileAttributes(token, mockHandlers);
     expect(result).toEqual(expected);
-    expect(fn).not.toHaveBeenCalled();
+    expect(mockHandlers.parseStringArray).not.toHaveBeenCalled();
+    expect(mockHandlers.parseObject).not.toHaveBeenCalled();
+    expect(mockHandlers.parseObjectArray).not.toHaveBeenCalled();
   });
 });

--- a/src/rmmz/plugin/core/attributes.string.test.ts
+++ b/src/rmmz/plugin/core/attributes.string.test.ts
@@ -1,8 +1,17 @@
+import type { MockedObject } from "vitest";
 import { describe, expect, test, vi } from "vitest";
 import type { ParamSoruceRecord } from "./attributes";
 import { compileAttributes } from "./attributes";
 import type { StringParam, StringArrayParam } from "./params";
 import type { PluginParamTokens } from "./parse";
+import type { DeepJSONParserHandlers } from "./rmmzJSON/types/handlers";
+
+const createHandlers = (): MockedObject<DeepJSONParserHandlers> => ({
+  parseStringArray: vi.fn(),
+  parseObject: vi.fn(),
+  parseObjectArray: vi.fn(),
+});
+
 describe("compileAttributes", () => {
   describe("string", () => {
     test("minimum set", () => {
@@ -17,10 +26,12 @@ describe("compileAttributes", () => {
         kind: "string",
         default: "abc",
       };
-      const fn = vi.fn(() => {});
-      const result = compileAttributes(tokens, fn);
+      const mockHandlers = createHandlers();
+      const result = compileAttributes(tokens, mockHandlers);
       expect(result).toEqual(expected);
-      expect(fn).not.toHaveBeenCalled();
+      expect(mockHandlers.parseStringArray).not.toHaveBeenCalled();
+      expect(mockHandlers.parseObject).not.toHaveBeenCalled();
+      expect(mockHandlers.parseObjectArray).not.toHaveBeenCalled();
     });
 
     test("full set", () => {
@@ -41,10 +52,12 @@ describe("compileAttributes", () => {
         desc: "String Description",
         parent: "Parent String",
       };
-      const fn = vi.fn(() => {});
-      const result = compileAttributes(tokens, fn);
+      const mockHandlers = createHandlers();
+      const result = compileAttributes(tokens, mockHandlers);
       expect(result).toEqual(expected);
-      expect(fn).not.toHaveBeenCalled();
+      expect(mockHandlers.parseStringArray).not.toHaveBeenCalled();
+      expect(mockHandlers.parseObject).not.toHaveBeenCalled();
+      expect(mockHandlers.parseObjectArray).not.toHaveBeenCalled();
     });
   });
 
@@ -61,11 +74,14 @@ describe("compileAttributes", () => {
         kind: "string[]",
         default: ["a", "b", "c"],
       };
-      const fn = vi.fn(() => {});
 
-      const result = compileAttributes(tokens, fn);
+      const mockHandlers = createHandlers();
+
+      const result = compileAttributes(tokens, mockHandlers);
       expect(result).toEqual(expected);
-      expect(fn).not.toHaveBeenCalled();
+      expect(mockHandlers.parseStringArray).not.toHaveBeenCalled();
+      expect(mockHandlers.parseObject).not.toHaveBeenCalled();
+      expect(mockHandlers.parseObjectArray).not.toHaveBeenCalled();
     });
 
     test("empty array", () => {
@@ -80,10 +96,13 @@ describe("compileAttributes", () => {
         kind: "string[]",
         default: [],
       };
-      const fn = vi.fn(() => {});
-      const result = compileAttributes(tokens, fn);
+      const mockHandlers = createHandlers();
+
+      const result = compileAttributes(tokens, mockHandlers);
       expect(result).toEqual(expected);
-      expect(fn).not.toHaveBeenCalled();
+      expect(mockHandlers.parseStringArray).not.toHaveBeenCalled();
+      expect(mockHandlers.parseObject).not.toHaveBeenCalled();
+      expect(mockHandlers.parseObjectArray).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/rmmz/plugin/core/attributes.string.test.ts
+++ b/src/rmmz/plugin/core/attributes.string.test.ts
@@ -2,15 +2,19 @@ import type { MockedObject } from "vitest";
 import { describe, expect, test, vi } from "vitest";
 import type { ParamSoruceRecord } from "./attributes";
 import { compileAttributes } from "./attributes";
+import { createDeepJSONParserHandlers } from "./deepJSONHandler";
 import type { StringParam, StringArrayParam } from "./params";
 import type { PluginParamTokens } from "./parse";
 import type { DeepJSONParserHandlers } from "./rmmzJSON/types/handlers";
 
-const createHandlers = (): MockedObject<DeepJSONParserHandlers> => ({
-  parseStringArray: vi.fn(),
-  parseObject: vi.fn(),
-  parseObjectArray: vi.fn(),
-});
+const createHandlers = (): MockedObject<DeepJSONParserHandlers> => {
+  const parser = createDeepJSONParserHandlers();
+  return {
+    parseStringArray: vi.fn((s: string) => parser.parseStringArray(s)),
+    parseObject: vi.fn((s: string) => parser.parseObject(s)),
+    parseObjectArray: vi.fn((s: string) => parser.parseObjectArray(s)),
+  };
+};
 
 describe("compileAttributes", () => {
   describe("string", () => {
@@ -79,7 +83,10 @@ describe("compileAttributes", () => {
 
       const result = compileAttributes(tokens, mockHandlers);
       expect(result).toEqual(expected);
-      expect(mockHandlers.parseStringArray).not.toHaveBeenCalled();
+      expect(mockHandlers.parseStringArray).toHaveBeenCalledWith(
+        tokens.attr.default
+      );
+      expect(mockHandlers.parseStringArray).toHaveBeenCalledTimes(1);
       expect(mockHandlers.parseObject).not.toHaveBeenCalled();
       expect(mockHandlers.parseObjectArray).not.toHaveBeenCalled();
     });
@@ -100,7 +107,10 @@ describe("compileAttributes", () => {
 
       const result = compileAttributes(tokens, mockHandlers);
       expect(result).toEqual(expected);
-      expect(mockHandlers.parseStringArray).not.toHaveBeenCalled();
+      expect(mockHandlers.parseStringArray).toHaveBeenCalledWith(
+        tokens.attr.default
+      );
+      expect(mockHandlers.parseStringArray).toHaveBeenCalledTimes(1);
       expect(mockHandlers.parseObject).not.toHaveBeenCalled();
       expect(mockHandlers.parseObjectArray).not.toHaveBeenCalled();
     });

--- a/src/rmmz/plugin/core/attributes.struct.test.ts
+++ b/src/rmmz/plugin/core/attributes.struct.test.ts
@@ -1,9 +1,11 @@
+import type { MockedObject } from "vitest";
 import { describe, expect, test, vi } from "vitest";
 import type { ParamSoruceRecord } from "./attributes";
 import { compileAttributes } from "./attributes";
 import type { StructRefParam, StructArrayRefParam } from "./params";
 import type { PluginParamTokens } from "./parse";
 import { parseDeepJSON, stringifyDeepJSON } from "./rmmzJSON";
+import type { DeepJSONParserHandlers } from "./rmmzJSON/types/handlers";
 
 interface Person {
   name: string;
@@ -13,6 +15,15 @@ const mockStruct = {
   name: "",
   age: 0,
 } as const satisfies Person;
+
+const createMockHandlers = (
+  mockString: string[],
+  mockedStruct: Person
+): MockedObject<DeepJSONParserHandlers> => ({
+  parseStringArray: vi.fn().mockReturnValue(mockString),
+  parseObject: vi.fn().mockReturnValue(mockedStruct),
+  parseObjectArray: vi.fn().mockReturnValue([mockedStruct]),
+});
 
 describe("compileAttributes", () => {
   test("struct ref", () => {

--- a/src/rmmz/plugin/core/attributes.ts
+++ b/src/rmmz/plugin/core/attributes.ts
@@ -1,5 +1,4 @@
 import { createDeepJSONParserHandlers } from "./deepJSONHandler";
-import { createDefaultStruct, createDefaultStructArray } from "./defaultStruct";
 import type { MappingTable } from "./mapping/mapping";
 import { compileParam, compileArrayParam } from "./mapping/mapping";
 import type {
@@ -22,7 +21,6 @@ import type {
 import type { ParamError } from "./params/types/error";
 import type { PluginParamTokens, OptionItem } from "./parse";
 import { KEYWORD_KIND } from "./parse";
-import { parseDeepJSON } from "./rmmzJSON";
 import type { DeepJSONParserHandlers } from "./rmmzJSON/types/handlers";
 
 type MappingTableEx<T> = MappingTable<Omit<T, "kind">>;
@@ -86,28 +84,6 @@ const compileStructArrayParam3 = (
     default: defaultValue,
     ...ee,
   };
-};
-
-/**
- * @deprecated use compileAttributes instead
- */
-export const compileAttributesOld = (
-  tokens: PluginParamTokens,
-  objectParseFn: (json: string) => unknown = parseDeepJSON
-): PrimitiveParam => {
-  if (KEYWORD_KIND in tokens.attr) {
-    const func = TABLE2[tokens.attr.kind as keyof typeof TABLE2];
-    if (func) {
-      return func(tokens);
-    }
-    if (tokens.attr.kind === "struct") {
-      return compileStructParam2(tokens, objectParseFn);
-    }
-    if (tokens.attr.kind === "struct[]") {
-      return compileStructArrayParam2(tokens, objectParseFn);
-    }
-  }
-  return compileParam("any", "", tokens.attr, STRING);
 };
 
 const attrString = (value: string): string => value;
@@ -271,42 +247,6 @@ const compileDataId = <Kind extends DataKind_RpgUnion | DataKind_SystemUnion>(
     parent: attrString,
   } as const satisfies MappingTableEx<GenericIdParam>;
   return compileParam(kind, 0, tokens.attr, DATA_ID);
-};
-
-const compileStructParam2 = (
-  tokens: PluginParamTokens,
-  fn: (deepJSON: string) => unknown
-): StructRefParam => {
-  const defaultValue = createDefaultStruct(tokens.attr.default, fn);
-  const STRUCT_REF = {
-    text: attrString,
-    desc: attrString,
-    parent: attrString,
-  } as const;
-  return {
-    struct: tokens.attr.struct || "",
-    ...compileParam("struct", defaultValue, tokens.attr, STRUCT_REF),
-  };
-};
-
-const compileStructArrayParam2 = (
-  tokens: PluginParamTokens,
-  objectParseFn: (json: string) => unknown
-): StructArrayRefParam => {
-  const defaultValue = createDefaultStructArray(
-    tokens.attr.default,
-    objectParseFn
-  );
-  const STRUCT_ARRAY = {
-    text: attrString,
-    desc: attrString,
-    parent: attrString,
-  } as const;
-  return {
-    struct: tokens.attr.struct || "",
-    ...compileParam("struct[]", defaultValue, tokens.attr, STRUCT_ARRAY),
-    default: defaultValue,
-  };
 };
 
 const TABLE2 = {

--- a/src/rmmz/plugin/core/compilePluginAsArraySchema.ts
+++ b/src/rmmz/plugin/core/compilePluginAsArraySchema.ts
@@ -1,4 +1,4 @@
-import { compileAttributes } from "./attributes";
+import { compileAttributesOld } from "./attributes";
 import type {
   PluginSchemaArray,
   PluginParam,
@@ -36,7 +36,7 @@ const mapParams = (
   return params.map(
     (p): PluginParam => ({
       name: p.name,
-      attr: compileAttributes(p, fn),
+      attr: compileAttributesOld(p, fn),
     })
   );
 };

--- a/src/rmmz/plugin/core/deepJSONHandler.ts
+++ b/src/rmmz/plugin/core/deepJSONHandler.ts
@@ -1,0 +1,22 @@
+import type { DeepJSONParserHandlers } from "./rmmzJSON/types/handlers";
+
+export const createDeepJSONParserHandlers = (): DeepJSONParserHandlers => ({
+  parseStringArray: () => {
+    return {
+      value: [],
+      errors: [],
+    };
+  },
+  parseObjectArray: () => {
+    return {
+      value: [],
+      errors: [],
+    };
+  },
+  parseObject: () => {
+    return {
+      value: {},
+      errors: [],
+    };
+  },
+});

--- a/src/rmmz/plugin/core/deepJSONHandler.ts
+++ b/src/rmmz/plugin/core/deepJSONHandler.ts
@@ -1,3 +1,4 @@
+import { parseDeepJSON } from "./rmmzJSON";
 import type { DeepJSONParserHandlers } from "./rmmzJSON/types/handlers";
 
 export const createDeepJSONParserHandlers = (): DeepJSONParserHandlers => ({
@@ -13,9 +14,9 @@ export const createDeepJSONParserHandlers = (): DeepJSONParserHandlers => ({
       errors: [],
     };
   },
-  parseObject: () => {
+  parseObject: (json: string) => {
     return {
-      value: {},
+      value: parseDeepJSON(json) as object,
       errors: [],
     };
   },

--- a/src/rmmz/plugin/core/deepJSONHandler.ts
+++ b/src/rmmz/plugin/core/deepJSONHandler.ts
@@ -2,9 +2,10 @@ import { parseDeepJSON } from "./rmmzJSON";
 import type { DeepJSONParserHandlers } from "./rmmzJSON/types/handlers";
 
 export const createDeepJSONParserHandlers = (): DeepJSONParserHandlers => ({
-  parseStringArray: () => {
+  parseStringArray: (json: string) => {
+    const value = parseStringArray(json);
     return {
-      value: [],
+      value: value,
       errors: [],
     };
   },
@@ -21,3 +22,16 @@ export const createDeepJSONParserHandlers = (): DeepJSONParserHandlers => ({
     };
   },
 });
+
+const parseStringArray = (value: string): string[] => {
+  try {
+    const array = JSON.parse(value);
+    if (
+      Array.isArray(array) &&
+      array.every((item) => typeof item === "string")
+    ) {
+      return array;
+    }
+  } catch {}
+  return [];
+};

--- a/src/rmmz/plugin/core/rmmzJSON/types/handlers.ts
+++ b/src/rmmz/plugin/core/rmmzJSON/types/handlers.ts
@@ -1,5 +1,12 @@
-export interface DeepJSONParserHandlers {
-  parseStringArray: (json: string) => string[];
-  parseObject: (json: string) => Record<string, unknown>;
-  parseObjectArray: (json: string) => Record<string, unknown>[];
+import type { ParamError } from "../../params/types/error";
+
+export interface DeepJSONParserHandlers<E = ParamError> {
+  parseStringArray: (json: string) => DeepParseResult<string[], E>;
+  parseObject: (json: string) => DeepParseResult<object, E>;
+  parseObjectArray: (json: string) => DeepParseResult<object[], E>;
+}
+
+export interface DeepParseResult<T, E> {
+  value: T;
+  errors: E[];
 }

--- a/src/rmmz/plugin/plugin.ts
+++ b/src/rmmz/plugin/plugin.ts
@@ -1,7 +1,6 @@
 import type { JSONValue } from "@RmmzPluginSchema/libs/jsonPath";
-import { parseDeepJSON, parseDeepRecord, type PluginSchema } from "./core";
+import { parseDeepRecord, PluginSchema } from "./core";
 import { compilePluginToObject } from "./core/compilePlugin";
-import type { CCC } from "./core/compilePluginAsArraySchema";
 import { compilePluginAsArraySchema } from "./core/compilePluginAsArraySchema";
 import type { ParsedPlugin } from "./core/parse";
 import { parsePlugin } from "./core/parse/parse";
@@ -9,6 +8,8 @@ import type { PluginJSON } from "./core/pluginJSONTypes";
 import { parsePluginParamRecord } from "./pluginsJS/jsToJSON";
 import type { PluginParamsObject, PluginParamsRecord } from "./pluginsJS/types";
 import type { PluginInput } from "./types";
+import { createDeepJSONParserHandlers } from "./core/deepJSONHandler";
+import { DeepJSONParserHandlers } from "./core/rmmzJSON/types/handlers";
 
 export const paramObjectFromPluginRecord = (
   record: PluginParamsRecord
@@ -22,15 +23,14 @@ export const pluginSourceToJSON = (text: string): PluginJSON => {
 
 export const pluginSourceToArraySchema = (
   input: PluginInput,
-  fn: (structDefault: string, category: CCC) => unknown = (s: string) =>
-    parseDeepJSON(s)
+  parser: DeepJSONParserHandlers = createDeepJSONParserHandlers()
 ): PluginSchema => {
   const tokens: ParsedPlugin = parsePlugin(input.source, input.locale);
   return {
     meta: tokens.meta,
     pluginName: input.pluginName,
     target: "MZ",
-    schema: compilePluginAsArraySchema(tokens, fn),
+    schema: compilePluginAsArraySchema(tokens, parser),
   };
 };
 


### PR DESCRIPTION
defaultのパース処理をハンドラに移譲するようにした
こうすることで例外の問題を外部の責任にできる