### PR TITLE
ParseTest

### DIFF
--- a/src/features/genarator/tokens.test.ts
+++ b/src/features/genarator/tokens.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test, vi } from "vitest";
 import type { PluginInput } from "@RmmzPluginSchema/rmmz/index";
 import { pluginSourceToArraySchema } from "@RmmzPluginSchema/rmmz/index";
 import type { PluginStructTokens } from "@RmmzPluginSchema/rmmz/plugin/core/parse";
-import { parsePlugin } from "@RmmzPluginSchema/rmmz/plugin/core/parse/parse";
+import { parsePluginByLocale } from "@RmmzPluginSchema/rmmz/plugin/core/parse/parse";
 import { generatePluginAnnotation } from "./generator";
 import {
   generateStructTokenBlock,
@@ -114,7 +114,7 @@ describe("plugin annotation <-> token roundtrip", () => {
       const handlers = createHandlers();
       const result: PluginAnnotationTokens = generatePluginAnnotation(
         schema,
-        handlers
+        handlers,
       );
       expect(handlers.stringArray).not.toHaveBeenCalled();
       expect(handlers.numberArray).not.toHaveBeenCalled();
@@ -189,7 +189,7 @@ describe("generateStructTokenBlock", () => {
     };
 
     const lines = ["/*:ja", "*/", ...expectedTokens].join("\n");
-    const result = parsePlugin(lines, "ja");
+    const result = parsePluginByLocale(lines, "ja");
     expect(result.structs).toEqual([struct]);
   });
 });

--- a/src/rmmz/plugin/core/compilePlugin.ts
+++ b/src/rmmz/plugin/core/compilePlugin.ts
@@ -2,7 +2,7 @@ import { compilePluginParam } from "./attributes";
 import type { DeepJSONParserHandlers } from "./deepJSONHandler";
 import { createDeepJSONParserHandlers } from "./deepJSONHandler";
 import type { PrimitiveParam } from "./params";
-import { parsePlugin } from "./parse/parse";
+import { parsePluginByLocale } from "./parse/parse";
 import type {
   ParsedPlugin,
   PluginCommandTokens,
@@ -16,7 +16,7 @@ import type {
 } from "./pluginJSONTypes";
 
 export const compilePluginToObject = (text: string): PluginJSON => {
-  return compilePluginToObjectCore(parsePlugin(text));
+  return compilePluginToObjectCore(parsePluginByLocale(text, ""));
 };
 
 const compilePluginToObjectCore = (parsedPlugin: ParsedPlugin): PluginJSON => {

--- a/src/rmmz/plugin/core/parse/index.ts
+++ b/src/rmmz/plugin/core/parse/index.ts
@@ -1,5 +1,6 @@
 export * from "./block";
 export * from "./option";
+export * from "./parse";
 export * from "./selectOption";
 export type * from "./types";
 export * from "./types/keyword/constants";

--- a/src/rmmz/plugin/core/parse/parse.command.test.ts
+++ b/src/rmmz/plugin/core/parse/parse.command.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest";
-import { parsePlugin } from "./parse";
+import { parsePluginByLocale } from "./parse";
 import type { ParsedPlugin, PluginCommandTokens } from "./types";
 
 describe("parsePlugin", () => {
@@ -20,7 +20,7 @@ describe("parsePlugin", () => {
       "@default abc",
       "*/",
     ];
-    const result: ParsedPlugin = parsePlugin(mockTexts.join("\n"));
+    const result: ParsedPlugin = parsePluginByLocale(mockTexts.join("\n"));
     const expected: PluginCommandTokens = {
       command: "save",
       text: "writeSave",
@@ -64,7 +64,7 @@ describe("parsePlugin", () => {
       "@default abc",
       "*/",
     ];
-    const result: ParsedPlugin = parsePlugin(mockTexts.join("\n"));
+    const result: ParsedPlugin = parsePluginByLocale(mockTexts.join("\n"));
     const expected: PluginCommandTokens[] = [
       {
         command: "save",
@@ -115,7 +115,7 @@ describe("parsePlugin", () => {
       "@default abc",
       "*/",
     ];
-    const result: ParsedPlugin = parsePlugin(mockTexts.join("\n"));
+    const result: ParsedPlugin = parsePluginByLocale(mockTexts.join("\n"));
     const expected: PluginCommandTokens[] = [
       {
         command: "save",

--- a/src/rmmz/plugin/core/parse/parse.help.test.ts
+++ b/src/rmmz/plugin/core/parse/parse.help.test.ts
@@ -1,12 +1,12 @@
 import { describe, test, expect } from "vitest";
-import { parsePlugin } from "./parse";
+import { parsePluginByLocale, parsePlugin } from "./parse";
 import type {
   ParsedPlugin,
   PluginCommandTokens,
   PluginParamTokens,
 } from "./types";
 
-const mockTexts: string[] = [
+const mockInput: string[] = [
   "/*:",
   "@command save",
   "@arg arg1",
@@ -33,57 +33,52 @@ const mockTexts: string[] = [
   "*/",
 ];
 
-describe("parsePlugin", () => {
+const expectedParams: PluginParamTokens[] = [
+  { name: "gameTitle", attr: { kind: "string", default: "'My Game'" } },
+  { name: "data", attr: { kind: "number", default: "123" } },
+];
+const expectedCommands: PluginCommandTokens[] = [
+  {
+    command: "save",
+    args: [{ name: "arg1", attr: { kind: "number", default: "123" } }],
+  },
+  {
+    command: "load",
+    args: [{ name: "slot", attr: { kind: "number", default: "1" } }],
+  },
+];
+
+const helpLines: string[] = ["aaaa", "bbbb", "cccc"];
+describe("parsePluginByLocale", () => {
   test("should parse plugin annotations correctly", () => {
-    const result: ParsedPlugin = parsePlugin(mockTexts.join("\n"));
+    const result: ParsedPlugin = parsePluginByLocale(mockInput.join("\n"));
     expect(result.meta).toBeDefined();
-    expect(result.helpLines).toEqual(["aaaa", "bbbb", "cccc"]);
+    expect(result.helpLines).toEqual(helpLines);
   });
-
   test("should parse parameters correctly", () => {
-    const result: ParsedPlugin = parsePlugin(mockTexts.join("\n"));
-
-    const expected: PluginParamTokens[] = [
-      {
-        name: "gameTitle",
-        attr: {
-          kind: "string",
-          default: "'My Game'",
-        },
-      },
-      {
-        name: "data",
-        attr: {
-          kind: "number",
-          default: "123",
-        },
-      },
-    ];
-    expect(result.params).toEqual(expected);
+    const result: ParsedPlugin = parsePluginByLocale(mockInput.join("\n"));
+    expect(result.params).toEqual(expectedParams);
   });
   test("should parse commands correctly", () => {
-    const result: ParsedPlugin = parsePlugin(mockTexts.join("\n"));
+    const result: ParsedPlugin = parsePluginByLocale(mockInput.join("\n"));
 
-    const expected: PluginCommandTokens[] = [
-      {
-        command: "save",
-        args: [
-          {
-            name: "arg1",
-            attr: { kind: "number", default: "123" },
-          },
-        ],
-      },
-      {
-        command: "load",
-        args: [
-          {
-            name: "slot",
-            attr: { kind: "number", default: "1" },
-          },
-        ],
-      },
-    ];
-    expect(result.commands).toEqual(expected);
+    expect(result.commands).toEqual(expectedCommands);
+  });
+});
+
+describe("parsePlugin", () => {
+  test("should parse plugin annotations correctly", () => {
+    const result: ParsedPlugin[] = parsePlugin(mockInput.join("\n"));
+    expect(result.length).toBe(1);
+    expect(result[0].meta).toBeDefined();
+    expect(result[0].helpLines).toEqual(helpLines);
+  });
+  test("should parse parameters correctly", () => {
+    const result: ParsedPlugin[] = parsePlugin(mockInput.join("\n"));
+    expect(result[0].params).toEqual(expectedParams);
+  });
+  test("should parse commands correctly", () => {
+    const result: ParsedPlugin[] = parsePlugin(mockInput.join("\n"));
+    expect(result[0].commands).toEqual(expectedCommands);
   });
 });

--- a/src/rmmz/plugin/core/parse/parse.locale.test.ts
+++ b/src/rmmz/plugin/core/parse/parse.locale.test.ts
@@ -1,85 +1,81 @@
 import { describe, test, expect } from "vitest";
-import { parsePlugin } from "./parse";
+import { parsePlugin, parsePluginByLocale } from "./parse";
 import type {
   ParsedPlugin,
   PluginCommandTokens,
   PluginDependencies,
   PluginStructTokens,
 } from "./types";
+const input: string = [
+  "/*~struct~MyStruct:ja",
+  "@param param1",
+  "@text パラメータ1",
+  "@type number",
+  "*/",
+
+  "/*~struct~MyStruct",
+  "@param param1",
+  "@text Parameter 1",
+  "@type number",
+  "*/",
+
+  "/*:",
+  "@command save",
+  "@text writeSave",
+  "@desc write Save File",
+  "@arg arg1",
+  "@text arg1 text",
+  "@type number",
+  "@default 123",
+
+  "@base ABC",
+  "*/",
+
+  "/*:ja",
+  "@command 保存",
+  "@text セーブを書き込む",
+  "@desc セーブファイルを書き込みます",
+  "@arg arg1",
+  "@text 引数1のテキスト",
+  "@type number",
+  "@default 123",
+
+  "@base XYZ",
+  "*/",
+].join("\n");
 
 describe("parsePlugin", () => {
-  const input = [
-    "/*~struct~MyStruct:ja",
-    "@param param1",
-    "@text パラメータ1",
-    "@type number",
-    "*/",
-
-    "/*~struct~MyStruct",
-    "@param param1",
-    "@text Parameter 1",
-    "@type number",
-    "*/",
-
-    "/*:",
-    "@command save",
-    "@text writeSave",
-    "@desc write Save File",
-    "@arg arg1",
-    "@text arg1 text",
-    "@type number",
-    "@default 123",
-
-    "@base ABC",
-    "*/",
-
-    "/*:ja",
-    "@command 保存",
-    "@text セーブを書き込む",
-    "@desc セーブファイルを書き込みます",
-    "@arg arg1",
-    "@text 引数1のテキスト",
-    "@type number",
-    "@default 123",
-
-    "@base XYZ",
-    "*/",
-  ].join("\n");
-
+  const expectedCommandsJA: PluginCommandTokens[] = [
+    {
+      command: "保存",
+      text: "セーブを書き込む",
+      desc: "セーブファイルを書き込みます",
+      args: [
+        {
+          name: "arg1",
+          attr: { kind: "number", text: "引数1のテキスト", default: "123" },
+        },
+      ],
+    },
+  ];
+  const expectedStructsJA: PluginStructTokens[] = [
+    {
+      name: "MyStruct",
+      params: [
+        { name: "param1", attr: { kind: "number", text: "パラメータ1" } },
+      ],
+    },
+  ];
   test("should parse plugin with locale 'ja' correctly", () => {
-    const expectedCommands: PluginCommandTokens[] = [
-      {
-        command: "保存",
-        text: "セーブを書き込む",
-        desc: "セーブファイルを書き込みます",
-        args: [
-          {
-            name: "arg1",
-            attr: { kind: "number", text: "引数1のテキスト", default: "123" },
-          },
-        ],
-      },
-    ];
-    const expectedStructs: PluginStructTokens[] = [
-      {
-        name: "MyStruct",
-        params: [
-          {
-            name: "param1",
-            attr: { kind: "number", text: "パラメータ1" },
-          },
-        ],
-      },
-    ];
     const dep: PluginDependencies = {
       base: ["XYZ"],
       orderBefore: [],
       orderAfter: [],
     };
 
-    const result: ParsedPlugin = parsePlugin(input, "ja");
-    expect(result.commands).toEqual(expectedCommands);
-    expect(result.structs).toEqual(expectedStructs);
+    const result: ParsedPlugin = parsePluginByLocale(input, "ja");
+    expect(result.commands).toEqual(expectedCommandsJA);
+    expect(result.structs).toEqual(expectedStructsJA);
     expect(result.dependencies).toEqual(dep);
   });
   test("should parse plugin with locale 'en' correctly", () => {
@@ -113,9 +109,65 @@ describe("parsePlugin", () => {
       orderAfter: [],
     };
 
-    const result: ParsedPlugin = parsePlugin(input, "en");
+    const result: ParsedPlugin = parsePluginByLocale(input, "en");
     expect(result.commands).toEqual(expectedCommands);
     expect(result.structs).toEqual(expectedStructs);
     expect(result.dependencies).toEqual(dep);
+  });
+
+  test("parsePlugin should return all locales", () => {
+    const expected: ParsedPlugin[] = [
+      {
+        locale: undefined,
+        commands: [
+          {
+            command: "save",
+            text: "writeSave",
+            desc: "write Save File",
+            args: [
+              {
+                name: "arg1",
+                attr: { kind: "number", text: "arg1 text", default: "123" },
+              },
+            ],
+          },
+        ],
+        params: [],
+        helpLines: [],
+        meta: {},
+        dependencies: {
+          base: ["ABC"],
+          orderBefore: [],
+          orderAfter: [],
+        },
+        structs: [
+          {
+            name: "MyStruct",
+            params: [
+              {
+                name: "param1",
+                attr: { kind: "number", text: "Parameter 1" },
+              },
+            ],
+          },
+        ],
+      },
+      {
+        locale: "ja",
+        commands: expectedCommandsJA,
+        params: [],
+        helpLines: [],
+        meta: {},
+        dependencies: {
+          base: ["XYZ"],
+          orderBefore: [],
+          orderAfter: [],
+        },
+        structs: expectedStructsJA,
+      },
+    ];
+    const result: ParsedPlugin[] = parsePlugin(input);
+    expect(result).toHaveLength(2);
+    expect(result).toEqual(expected);
   });
 });

--- a/src/rmmz/plugin/core/parse/parse.meta.test.ts
+++ b/src/rmmz/plugin/core/parse/parse.meta.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { parsePlugin } from "./parse";
+import { parsePluginByLocale } from "./parse";
 import type { ParsedPlugin } from "./types";
 
 describe("parsePlugin", () => {
   it("returns an empty meta object for empty input", () => {
-    const result: ParsedPlugin = parsePlugin("");
+    const result: ParsedPlugin = parsePluginByLocale("");
     expect(result.meta).toEqual({});
   });
 
@@ -16,7 +16,7 @@ describe("parsePlugin", () => {
       "@url dummy-url",
       "*/",
     ].join("\n");
-    const result = parsePlugin(text);
+    const result = parsePluginByLocale(text);
     expect(result.meta.author).toBe("John Doe");
     expect(result.meta.plugindesc).toBe("This is a test plugin");
     expect(result.meta.url).toBe("dummy-url");
@@ -24,9 +24,9 @@ describe("parsePlugin", () => {
 
   it("prioritizes the first value when the same meta keyword is specified multiple times", () => {
     const text: string = ["/*:", "@author alice", "@author bob", "*/"].join(
-      "\n"
+      "\n",
     );
-    const result = parsePlugin(text);
+    const result = parsePluginByLocale(text);
     expect(result.meta.author).toBe("alice");
   });
 });

--- a/src/rmmz/plugin/core/parse/parse.option.test.ts
+++ b/src/rmmz/plugin/core/parse/parse.option.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest";
-import { parsePlugin } from "./parse";
+import { parsePluginByLocale } from "./parse";
 import type { ParsedPlugin, PluginParamTokens } from "./types";
 
 describe("parsePlugin", () => {
@@ -33,7 +33,7 @@ describe("parsePlugin", () => {
         },
       ],
     };
-    const result: ParsedPlugin = parsePlugin(tokens.join("\n"));
+    const result: ParsedPlugin = parsePluginByLocale(tokens.join("\n"));
     expect(result.params).toEqual(expected.params);
   });
 
@@ -67,7 +67,7 @@ describe("parsePlugin", () => {
         ],
       },
     ];
-    const result: ParsedPlugin = parsePlugin(tokens.join("\n"));
+    const result: ParsedPlugin = parsePluginByLocale(tokens.join("\n"));
     expect(result.params).toMatchObject(expected);
   });
   test("combo with options, default is one of option texts, option text is same as value", () => {
@@ -95,7 +95,7 @@ describe("parsePlugin", () => {
         ],
       },
     ];
-    const result: ParsedPlugin = parsePlugin(tokens.join("\n"));
+    const result: ParsedPlugin = parsePluginByLocale(tokens.join("\n"));
     expect(result.params).toEqual(expected);
   });
   test("combo with options, default is one of option texts, option text is different from value", () => {
@@ -114,7 +114,7 @@ describe("parsePlugin", () => {
         attr: { default: "komachi" },
       },
     ];
-    const result: ParsedPlugin = parsePlugin(tokens.join("\n"));
+    const result: ParsedPlugin = parsePluginByLocale(tokens.join("\n"));
     expect(result.params).toMatchObject(expected);
   });
 });

--- a/src/rmmz/plugin/core/parse/parse.param.test.ts
+++ b/src/rmmz/plugin/core/parse/parse.param.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest";
-import { parsePlugin } from "./parse";
+import { parsePluginByLocale } from "./parse";
 import type { ParsedPlugin, PluginParamTokens } from "./types";
 
 describe("parsePlugin", () => {
@@ -14,7 +14,7 @@ describe("parsePlugin", () => {
       "@default 123",
       "*/",
     ];
-    const result: ParsedPlugin = parsePlugin(mockTexts.join("\n"));
+    const result: ParsedPlugin = parsePluginByLocale(mockTexts.join("\n"));
 
     const expected: PluginParamTokens[] = [
       {
@@ -38,7 +38,7 @@ describe("parsePlugin", () => {
       "@default ",
       "*/",
     ];
-    const result: ParsedPlugin = parsePlugin(mockTexts.join("\n"));
+    const result: ParsedPlugin = parsePluginByLocale(mockTexts.join("\n"));
 
     const expected: PluginParamTokens[] = [
       {
@@ -59,7 +59,7 @@ describe("parsePlugin", () => {
       "@default ",
       "*/",
     ];
-    const result: ParsedPlugin = parsePlugin(mockTexts.join("\n"));
+    const result: ParsedPlugin = parsePluginByLocale(mockTexts.join("\n"));
 
     const expected: PluginParamTokens[] = [
       {
@@ -99,7 +99,7 @@ describe("parsePlugin", () => {
         },
       },
     ];
-    const result: ParsedPlugin = parsePlugin(mockTexts.join("\n"));
+    const result: ParsedPlugin = parsePluginByLocale(mockTexts.join("\n"));
     expect(result.params).toEqual(expected);
   });
 });

--- a/src/rmmz/plugin/core/parse/parse.space.test.ts
+++ b/src/rmmz/plugin/core/parse/parse.space.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest";
-import { parsePlugin } from "./parse";
+import { parsePluginByLocale } from "./parse";
 import type {
   ParsedPlugin,
   PluginCommandTokens,
@@ -37,7 +37,7 @@ describe("parsePlugin - space in param names", () => {
       },
     ];
 
-    const result: ParsedPlugin = parsePlugin(input.join("\n"));
+    const result: ParsedPlugin = parsePluginByLocale(input.join("\n"));
     expect(result.params).toEqual(expected);
   });
   test("should parse commands with spaces correctly", () => {
@@ -73,7 +73,7 @@ describe("parsePlugin - space in param names", () => {
         ],
       },
     ];
-    const result: ParsedPlugin = parsePlugin(input.join("\n"));
+    const result: ParsedPlugin = parsePluginByLocale(input.join("\n"));
     expect(result.commands).toEqual(expected);
   });
 });

--- a/src/rmmz/plugin/core/parse/parse.struct.test.ts
+++ b/src/rmmz/plugin/core/parse/parse.struct.test.ts
@@ -1,12 +1,12 @@
 import { describe, test, expect } from "vitest";
-import { parsePlugin } from "./parse";
+import { parsePluginByLocale } from "./parse";
 import type {
   ParsedPlugin,
   PluginParamTokens,
   PluginStructTokens,
 } from "./types/token";
 
-const createTokens = (structHead: string) => {
+const createTokens = (structHead: string): string[] => {
   return [
     "/*:",
     "@param num",
@@ -35,11 +35,11 @@ describe("parsePlugin", () => {
     const tokens: string[] = createTokens(`/*~struct~Person`);
     const src: string = tokens.join("\n");
     test("commands is empty", () => {
-      const result: ParsedPlugin = parsePlugin(src);
+      const result: ParsedPlugin = parsePluginByLocale(src);
       expect(result.commands).toEqual([]);
     });
     test("params", () => {
-      const result: ParsedPlugin = parsePlugin(src);
+      const result: ParsedPlugin = parsePluginByLocale(src);
       const expected: PluginParamTokens[] = [
         {
           name: "num",
@@ -57,7 +57,7 @@ describe("parsePlugin", () => {
       expect(result.params).toEqual(expected);
     });
     test("structs is defined", () => {
-      const result: ParsedPlugin = parsePlugin(src);
+      const result: ParsedPlugin = parsePluginByLocale(src);
       const struct: PluginStructTokens = {
         name: "Person",
         params: [
@@ -105,13 +105,13 @@ describe("parsePlugin", () => {
     test("structs with locale is defined", () => {
       const tokens: string[] = createTokens(`/*~struct~Person:ja`);
       const src: string = tokens.join("\n");
-      const result: ParsedPlugin = parsePlugin(src, "ja");
+      const result: ParsedPlugin = parsePluginByLocale(src, "ja");
       expect(result.structs).toEqual([expectedStruct]);
     });
     test("structs with locale is defined", () => {
       const tokens: string[] = createTokens(`/*~struct~Person:ja  `);
       const src: string = tokens.join("\n");
-      const result: ParsedPlugin = parsePlugin(src, "ja");
+      const result: ParsedPlugin = parsePluginByLocale(src, "ja");
       expect(result.structs).toEqual([expectedStruct]);
     });
   });

--- a/src/rmmz/plugin/core/parse/parse.ts
+++ b/src/rmmz/plugin/core/parse/parse.ts
@@ -60,14 +60,14 @@ const bbb = (
   };
 };
 
-export const parsePlugin2 = (text: string): ParsedPlugin[] => {
+export const parsePlugin = (text: string): ParsedPlugin[] => {
   const blocks: Block = splitBlock(text);
   return blocks.bodies.map((body): ParsedPlugin => bbb(body, blocks.structs));
 };
 
-export const parsePlugin = (
+export const parsePluginByLocale = (
   text: string,
-  locale: string = "en",
+  locale: string = "",
 ): ParsedPlugin => {
   const blocks: Block = splitBlock(text);
   const structs = filterSturctByLocale(blocks.structs, locale).map((s) =>

--- a/src/rmmz/plugin/plugin.ts
+++ b/src/rmmz/plugin/plugin.ts
@@ -6,7 +6,7 @@ import { compilePluginAsArraySchema } from "./core/compilePluginAsArraySchema";
 import type { DeepJSONParserHandlers } from "./core/deepJSONHandler";
 import { createDeepJSONParserHandlers } from "./core/deepJSONHandler";
 import type { ParsedPlugin } from "./core/parse";
-import { parsePlugin } from "./core/parse/parse";
+import { parsePluginByLocale } from "./core/parse/parse";
 import type { PluginJSON } from "./core/pluginJSONTypes";
 import type { PluginParamsRecord } from "./pluginsJS/types";
 import type { PluginInput } from "./types";
@@ -25,7 +25,7 @@ export const pluginSourceToArraySchema = (
   input: PluginInput,
   parser: DeepJSONParserHandlers = createDeepJSONParserHandlers(),
 ): PluginSchema => {
-  const tokens: ParsedPlugin = parsePlugin(input.source, input.locale);
+  const tokens: ParsedPlugin = parsePluginByLocale(input.source, input.locale);
   return {
     locale: input.locale,
     meta: tokens.meta,


### PR DESCRIPTION
パース処理を分割し、新しい関数を公開するようにした。この後でlocaleを必須に切り替える